### PR TITLE
Using unique_ptr for Region.

### DIFF
--- a/src/nupic/engine/Collections.cpp
+++ b/src/nupic/engine/Collections.cpp
@@ -39,6 +39,5 @@ template class nupic::Collection<OutputSpec>;
 template class nupic::Collection<InputSpec>;
 template class nupic::Collection<ParameterSpec>;
 template class nupic::Collection<CommandSpec>;
-template class nupic::Collection<Region *>;
 template class nupic::Collection<Link *>;
 template class nupic::Collection<Network::callbackItem>;

--- a/src/nupic/engine/Input.hpp
+++ b/src/nupic/engine/Input.hpp
@@ -65,7 +65,7 @@ public:
    * @param isSparse
    *        Whether the input is sparse. Default false
    */
-  Input(Region &region, NTA_BasicType type, bool isRegionLevel,
+  Input(Region *region, NTA_BasicType type, bool isRegionLevel,
         bool isSparse = false);
 
   /**
@@ -171,7 +171,7 @@ public:
    * @returns
    *         The mutable reference to the Region that the input belongs to
    */
-  Region &getRegion();
+  Region *getRegion();
 
   /**
    *
@@ -255,7 +255,9 @@ public:
   bool isSparse();
 
 private:
-  Region &region_;
+  Region *region_;  // Do not delete
+
+
   // buffer is concatenation of input buffers (after prepare), or,
   // if zeroCopyEnabled it points to the connected output
   bool isRegionLevel_;

--- a/src/nupic/engine/Link.cpp
+++ b/src/nupic/engine/Link.cpp
@@ -56,8 +56,8 @@ Link::Link(const std::string &linkType, const std::string &linkParams,
 Link::Link(const std::string &linkType, const std::string &linkParams,
            Output *srcOutput, Input *destInput, const size_t propagationDelay)
     : srcBuffer_(0) {
-  commonConstructorInit_(linkType, linkParams, srcOutput->getRegion().getName(),
-                         destInput->getRegion().getName(), srcOutput->getName(),
+  commonConstructorInit_(linkType, linkParams, srcOutput->getRegion()->getName(),
+                         destInput->getRegion()->getName(), srcOutput->getName(),
                          destInput->getName(), propagationDelay);
 
   connectToNetwork(srcOutput, destInput);
@@ -154,29 +154,29 @@ void Link::initialize(size_t destinationOffset) {
 
   if (src_->isRegionLevel()) {
     Dimensions d;
-    for (size_t i = 0; i < src_->getRegion().getDimensions().size(); i++) {
+    for (size_t i = 0; i < src_->getRegion()->getDimensions().size(); i++) {
       d.push_back(1);
     }
 
     NTA_CHECK(srcD.isDontcare() || srcD == d);
-  } else if (src_->getRegion().getDimensions() == oneD) {
+  } else if (src_->getRegion()->getDimensions() == oneD) {
     Dimensions d;
     for (size_t i = 0; i < srcD.size(); i++) {
       d.push_back(1);
     }
     NTA_CHECK(srcD.isDontcare() || srcD == d);
   } else {
-    NTA_CHECK(srcD.isDontcare() || srcD == src_->getRegion().getDimensions());
+    NTA_CHECK(srcD.isDontcare() || srcD == src_->getRegion()->getDimensions());
   }
 
   if (dest_->isRegionLevel()) {
     Dimensions d;
-    for (size_t i = 0; i < dest_->getRegion().getDimensions().size(); i++) {
+    for (size_t i = 0; i < dest_->getRegion()->getDimensions().size(); i++) {
       d.push_back(1);
     }
 
     NTA_CHECK(destD.isDontcare() || destD.isOnes());
-  } else if (dest_->getRegion().getDimensions() == oneD) {
+  } else if (dest_->getRegion()->getDimensions() == oneD) {
     Dimensions d;
     for (size_t i = 0; i < destD.size(); i++) {
       d.push_back(1);
@@ -184,7 +184,7 @@ void Link::initialize(size_t destinationOffset) {
     NTA_CHECK(destD.isDontcare() || destD == d);
   } else {
     NTA_CHECK(destD.isDontcare() ||
-              destD == dest_->getRegion().getDimensions());
+              destD == dest_->getRegion()->getDimensions());
   }
 
   // Validate sparse link
@@ -216,7 +216,7 @@ void Link::setSrcDimensions(Dimensions &dims) {
   size_t nodeElementCount = src_->getNodeOutputElementCount();
   if (nodeElementCount == 0) {
     nodeElementCount =
-        src_->getRegion().getNodeOutputElementCount(src_->getName());
+        src_->getRegion()->getNodeOutputElementCount(src_->getName());
   }
   impl_->setNodeOutputElementCount(nodeElementCount);
 
@@ -230,7 +230,7 @@ void Link::setDestDimensions(Dimensions &dims) {
   size_t nodeElementCount = src_->getNodeOutputElementCount();
   if (nodeElementCount == 0) {
     nodeElementCount =
-        src_->getRegion().getNodeOutputElementCount(src_->getName());
+        src_->getRegion()->getNodeOutputElementCount(src_->getName());
   }
   impl_->setNodeOutputElementCount(nodeElementCount);
 
@@ -269,12 +269,12 @@ const std::string Link::toString() const {
   std::stringstream ss;
   ss << "[" << getSrcRegionName() << "." << getSrcOutputName();
   if (src_) {
-    ss << " (region dims: " << src_->getRegion().getDimensions().toString()
+    ss << " (region dims: " << src_->getRegion()->getDimensions().toString()
        << ") ";
   }
   ss << " to " << getDestRegionName() << "." << getDestInputName();
   if (dest_) {
-    ss << " (region dims: " << dest_->getRegion().getDimensions().toString()
+    ss << " (region dims: " << dest_->getRegion()->getDimensions().toString()
        << ") ";
   }
   ss << " type: " << linkType_ << "]";
@@ -593,7 +593,7 @@ void Link::deserialize(std::istream &f) {
   f >> tag;
   NTA_CHECK(tag == "}");
   f.ignore(1);
-  
+
   if (_LINK_DEBUG)
     NTA_DEBUG << "Restored Link: " << *this;
 }

--- a/src/nupic/engine/Output.cpp
+++ b/src/nupic/engine/Output.cpp
@@ -33,7 +33,7 @@
 
 namespace nupic {
 
-Output::Output(Region &region, NTA_BasicType type, bool isRegionLevel,
+Output::Output(Region *region, NTA_BasicType type, bool isRegionLevel,
                bool isSparse)
     : region_(region), isRegionLevel_(isRegionLevel), name_("Unnamed"),
       nodeOutputElementCount_(0), isSparse_(isSparse) {
@@ -67,7 +67,7 @@ void Output::initialize(size_t count) {
   if (isRegionLevel_)
     dataCount = count;
   else
-    dataCount = count * region_.getDimensions().getCount();
+    dataCount = count * region_->getDimensions().getCount();
   if (dataCount != 0) {
     data_.allocateBuffer(dataCount);
     // Zero the buffer because unitialized outputs can screw up inspectors,
@@ -101,7 +101,7 @@ void Output::removeLink(Link *link) {
 
 bool Output::isRegionLevel() const { return isRegionLevel_; }
 
-Region &Output::getRegion() const { return region_; }
+Region *Output::getRegion() const { return region_; }
 bool Output::isSparse() const { return isSparse_; }
 
 void Output::setName(const std::string &name) { name_ = name; }

--- a/src/nupic/engine/Output.hpp
+++ b/src/nupic/engine/Output.hpp
@@ -54,7 +54,7 @@ public:
    * @param isSparse
    *        Whether the output is sparse. Default false
    */
-  Output(Region &region, NTA_BasicType type, bool isRegionLevel,
+  Output(Region *region, NTA_BasicType type, bool isRegionLevel,
          bool isSparse = false);
 
   /**
@@ -163,7 +163,7 @@ public:
    * @returns
    *         The mutable reference to the Region that the output belongs to
    */
-  Region &getRegion() const;
+  Region *getRegion() const;
 
   /**
    * Get the count of node output element.
@@ -183,7 +183,7 @@ public:
   bool isSparse() const;
 
 private:
-  Region &region_; // needed for number of nodes
+  Region *region_; // needed for number of nodes
   Array data_;
   bool isRegionLevel_;
   // order of links never matters, so store as a set

--- a/src/nupic/engine/Region.cpp
+++ b/src/nupic/engine/Region.cpp
@@ -90,7 +90,7 @@ void Region::createInputsAndOutputs_() {
     const std::pair<std::string, OutputSpec> &p = spec_->outputs.getByIndex(i);
     std::string outputName = p.first;
     const OutputSpec &os = p.second;
-    auto output = new Output(*this, os.dataType, os.regionLevel, os.sparse);
+    auto output = new Output(this, os.dataType, os.regionLevel, os.sparse);
     outputs_[outputName] = output;
     // keep track of name in the output also -- see note in Region.hpp
     output->setName(outputName);
@@ -102,7 +102,7 @@ void Region::createInputsAndOutputs_() {
     std::string inputName = p.first;
     const InputSpec &is = p.second;
 
-    auto input = new Input(*this, is.dataType, is.regionLevel, is.sparse);
+    auto input = new Input(this, is.dataType, is.regionLevel, is.sparse);
     inputs_[inputName] = input;
     // keep track of name in the input also -- see note in Region.hpp
     input->setName(inputName);

--- a/src/nupic/engine/Region.hpp
+++ b/src/nupic/engine/Region.hpp
@@ -426,7 +426,7 @@ public:
    *
    * @see setParameterString()
    */
-  std::string getParameterString(const std::string &name);
+  const std::string getParameterString(const std::string &name) const;
 
   /**
    * Tells whether the parameter is shared.

--- a/src/nupic/engine/RegionParameters.cpp
+++ b/src/nupic/engine/RegionParameters.cpp
@@ -131,7 +131,7 @@ void Region::setParameterString(const std::string &name, const std::string &s) {
   impl_->setParameterString(name, (Int64)-1, s);
 }
 
-std::string Region::getParameterString(const std::string &name) {
+const std::string Region::getParameterString(const std::string &name) const {
   return impl_->getParameterString(name, (Int64)-1);
 }
 

--- a/src/nupic/types/Types.hpp
+++ b/src/nupic/types/Types.hpp
@@ -167,6 +167,8 @@ enum LogLevel {
 
 #ifdef SWIG
 #undef NTA_INTERNAL
+#else
+#define NTA_INTERNAL 1
 #endif // SWIG
 
 #endif // NTA_TYPES_HPP

--- a/src/nupic/utils/Watcher.cpp
+++ b/src/nupic/utils/Watcher.cpp
@@ -101,6 +101,13 @@ void Watcher::watcherCallback(Network *net, UInt64 iteration, void *dataIn) {
     watchData watch = elem;
     std::string value;
     std::stringstream out;
+	// make sure the region pointer is good.
+	try {
+		watch.region = net->getRegion(watch.regionName);
+	}
+	catch(std::exception e) {
+		continue; // watched region no longer exists.
+	}
     if (watch.wType == parameter) {
       if (watch.isArray) // currently don't support uncloned arrays
       {
@@ -386,8 +393,12 @@ void Watcher::attachToNetwork(Network& net)
 
   for (UInt i = 0; i < data_.watches.size(); i++) {
     watch = data_.watches.at(i);
-    const Collection<Region *> &regions = net.getRegions();
-    watch.region = regions.getByName(watch.regionName);
+    const RegionMap &regions = net.getRegions();
+    RegionMap::const_iterator itr;
+	itr = regions.find(watch.regionName);
+	if (itr == regions.end()) continue;  // not being watched
+
+    watch.region = itr->second.get();
 
       //output general information for each watch
       out << watch.watchID << ", ";

--- a/src/test/unit/engine/HelloRegionTest.cpp
+++ b/src/test/unit/engine/HelloRegionTest.cpp
@@ -80,7 +80,7 @@ TEST(HelloRegionTest, demo) {
   // Get output
   const Real64 *buffer = (const Real64 *)outputArray.getBuffer();
   for (size_t i = 0; i < outputArray.getCount(); i++) {
-//    EXPECT_FLOAT_EQ(buffer[0], 0); //TODO add test, which values should be here? 
+//    EXPECT_FLOAT_EQ(buffer[0], 0); //TODO add test, which values should be here?
     std::cout << "  " << i << "    " << buffer[i] << "" << std::endl;
   }
 
@@ -97,7 +97,7 @@ TEST(HelloRegionTest, demo) {
   }
 //  EXPECT_EQ(net, net2);
 
-  Region *region2 = net2.getRegions().getByName("region"); //TODO add more checks and asserts here
+  Region *region2 = net2.getRegion("region"); //TODO add more checks and asserts here
   region2->executeCommand(loadFileArgs);
   ArrayRef outputArray2 = region2->getOutputData("dataOut");
   const Real64 *buffer2 = (const Real64 *)outputArray2.getBuffer();
@@ -106,7 +106,7 @@ TEST(HelloRegionTest, demo) {
   net2.run(DATA_SIZE);
 
   ASSERT_EQ(outputArray2.getCount(), outputArray.getCount());
-  for (size_t i = 0; i < sizeof &buffer / sizeof &buffer[0]; i++) { //TODO how output all values generated during run(4) ?? 
+  for (size_t i = 0; i < sizeof &buffer / sizeof &buffer[0]; i++) { //TODO how output all values generated during run(4) ??
 	  EXPECT_FLOAT_EQ(buffer[i], buffer2[i]);
 	  std::cout << " buffer " << buffer[i] << " buffer2: " << buffer2[i] << std::endl;
   }

--- a/src/test/unit/engine/InputTest.cpp
+++ b/src/test/unit/engine/InputTest.cpp
@@ -40,14 +40,14 @@ TEST(InputTest, BasicNetworkConstruction) {
   Region *r2 = net.addRegion("r2", "TestNode", "");
 
   // Test constructor
-  Input x(*r1, NTA_BasicType_Int32, true);
-  Input y(*r2, NTA_BasicType_Byte, false);
-  EXPECT_THROW(Input i(*r1, (NTA_BasicType)(NTA_BasicType_Last + 1), true),
+  Input x(r1, NTA_BasicType_Int32, true);
+  Input y(r2, NTA_BasicType_Byte, false);
+  EXPECT_THROW(Input i(r1, (NTA_BasicType)(NTA_BasicType_Last + 1), true),
                std::exception);
 
   // test getRegion()
-  ASSERT_EQ(r1, &(x.getRegion()));
-  ASSERT_EQ(r2, &(y.getRegion()));
+  ASSERT_EQ(r1, x.getRegion());
+  ASSERT_EQ(r2, y.getRegion());
 
   // test isRegionLevel()
   ASSERT_TRUE(x.isRegionLevel());

--- a/src/test/unit/engine/LinkTest.cpp
+++ b/src/test/unit/engine/LinkTest.cpp
@@ -354,7 +354,7 @@ TEST(LinkTest, DelayedLinkSerialization) {
     for (UInt i = 0; i < 4; i++)
       ASSERT_EQ(0, idata[i]);
   }
-  
+
 
 
   // At this point:
@@ -378,7 +378,7 @@ TEST(LinkTest, DelayedLinkSerialization) {
       ASSERT_EQ(100, idata[i]);
     }
   }
-  
+
   // What is serialized in the Delay buffer should be
   // all 0's for first row and all 10's for the second.
   // The stored output buffer would be all 100's.
@@ -391,8 +391,8 @@ TEST(LinkTest, DelayedLinkSerialization) {
 
   net2.initialize();
 
-  auto n2region1 = net2.getRegions().getByName("region1");
-  auto n2region2 = net2.getRegions().getByName("region2");
+  auto n2region1 = net2.getRegion("region1");
+  auto n2region2 = net2.getRegion("region2");
 
   Input *n2in1 = n2region1->getInput("bottomUpIn");
   Input *n2in2 = n2region2->getInput("bottomUpIn");
@@ -403,7 +403,7 @@ TEST(LinkTest, DelayedLinkSerialization) {
   ASSERT_TRUE(n2in2->getData() == in2->getData())   << "Deserialized bottomUpIn region2 does not match";
   ASSERT_TRUE(n2out1->getData() == out1->getData()) << "Deserialized bottomUpOut region1 does not match";
   ASSERT_EQ(n2in2->getData().getCount(), 64);
-  
+
   {
 	  Link* link = n2in2->findLink("region1", "bottomUpOut");
     VERBOSE << "Input2: " << *link;

--- a/src/test/unit/engine/PyRegionTest.cpp
+++ b/src/test/unit/engine/PyRegionTest.cpp
@@ -155,7 +155,7 @@ void testPynodeArrayParameters(Region *level2) {
 
 void testPynodeLinking() {
   std::cerr << "testPynodeLinking \n";
-  Network net = Network();
+  Network net;
 
   Region *region1 = net.addRegion("region1", "TestNode", "");
   Region *region2 = net.addRegion("region2", "py.TestNode", "");
@@ -370,9 +370,9 @@ void testWriteRead() {
   n1.save(ss);
   n2.load(ss);
 
-  const Collection<Region *> &regions = n2.getRegions();
-  const std::pair<std::string, Region *> &regionPair = regions.getByIndex(0);
-  Region *region2 = regionPair.second;
+  const RegionMap &regions = n2.getRegions();
+  RegionMap::const_iterator itr = regions.cbegin();
+  const Region *region2 = itr->second.get();
 
   NTA_CHECK(region2->getParameterInt32("int32Param") == int32Param);
   NTA_CHECK(region2->getParameterUInt32("uint32Param") == uint32Param);
@@ -416,14 +416,14 @@ int realmain(bool leakTest) {
   std::cout << "Creating network..." << std::endl;
   Network n;
 
-  std::cout << "Region count is " << n.getRegions().getCount() << ""
+  std::cout << "Region count is " << n.getRegions().size() << ""
             << std::endl;
 
   std::cout << "Adding a PyNode region..." << std::endl;
   Network::registerPyRegion("nupic.bindings.regions.TestNode", "TestNode");
   Region *level2 = n.addRegion("level2", "py.TestNode", "{int32Param: 444}");
 
-  std::cout << "Region count is " << n.getRegions().getCount() << ""
+  std::cout << "Region count is " << n.getRegions().size() << ""
             << std::endl;
   std::cout << "Node type: " << level2->getType() << "" << std::endl;
   std::cout << "Nodespec is:\n"

--- a/src/test/unit/utils/WatcherTest.cpp
+++ b/src/test/unit/utils/WatcherTest.cpp
@@ -53,7 +53,7 @@ TEST(WatcherTest, SampleNetwork) {
   Dimensions d;
   d.push_back(8);
   d.push_back(4);
-  n.getRegions().getByName("level1")->setDimensions(d);
+  n.getRegion("level1")->setDimensions(d);
   n.link("level1", "level2", "TestFanIn2", "");
   n.link("level2", "level3", "TestFanIn2", "");
   n.initialize();
@@ -107,8 +107,7 @@ TEST(WatcherTest, SampleNetwork) {
   // n.getRegions().getByName("level1")->getNodeAtIndex(1).setParameterUInt32("unclonedParam",
   // (UInt32)1); n.run(3); see if Watcher notices change in parameter values
   // after 3 iterations
-  n.getRegions().getByName("level1")->setParameterUInt64("uint64Param",
-                                                         (UInt64)66);
+  n.getRegion("level1")->setParameterUInt64("uint64Param",  (UInt64)66);
   n.run(3);
 
   // test flushFile() - this should produce output


### PR DESCRIPTION
This still will not pass Python Tests because the Collection calls are missing. Will fix.

This uses the unique_ptr for the Region. I will need to do this for Link as well.  This works.  It does make sure that the Region gets deleted if the region is removed from the collection. But there is a catch.   **A unique_ptr cannot be copied.**  That means that anything that contains it cannot be be copied so the copy constructor on the Network object had to be disabled.  This means that the region object or the Network object cannot be copied.  For example, 
    Network net = Network();
will fail.  Also, cannot pass the object by value...must be a reference to the object so it cannot be created in a function and returned to the function's caller as was done in one of he tests.  Consequently you will see that I am still passing the pointer to Region everywhere.  I could pass a reference to the unique_ptr as in   RegionPtr& r  but why not just pass Region *.

I also discovered that the Collection object does a serial lookup.  I replaced it with just a plain std::map.  However, that breaks the API and the unit tests have to change.  So I will have to go back and fix the Collection I guess.

So, given the 'cannot copy' restriction on std::unique_ptr, do you think this is still the right way to go?
