### PR TITLE
Fix Random default seed, Fix to compile with c++17

### DIFF
--- a/src/nupic/types/BasicType.cpp
+++ b/src/nupic/types/BasicType.cpp
@@ -581,10 +581,10 @@ void BasicType::convertArray(void *ptr1, NTA_BasicType toType, const void *ptr2,
     default:
       break;
     }
-  } catch (nupic::Exception e) {
+  } catch (nupic::Exception &e) {
     NTA_THROW << "Error Converting Array from " << BasicType::getName(fromType)
               << " to " << BasicType::getName(toType) << " " << e.getMessage();
-  } catch (std::exception e) {
+  } catch (std::exception &e) {
     NTA_THROW << "Error Converting Array from " << BasicType::getName(fromType)
               << " to " << BasicType::getName(toType) << " " << e.what();
   }

--- a/src/nupic/utils/Random.cpp
+++ b/src/nupic/utils/Random.cpp
@@ -37,10 +37,11 @@ bool Random::operator==(const Random &o) const {
 	 gen == o.gen;
 }
 
+std::mt19937 static_gen;
 
 Random::Random(UInt64 seed) {
   if (seed == 0) {
-    seed_ = gen(); //generate random value from HW RNG
+    seed_ = static_gen(); //generate random value from HW RNG
   } else {
     seed_ = seed;
   }


### PR DESCRIPTION
Without this gcc returns:
```
/home/dm/foobar/nupic.cpp/src/nupic/types/BasicType.cpp: In static member function ‘static void nupic::BasicType::convertArray(void*, NTA_BasicType, const void*, NTA_BasicType, size_t)’:
/home/dm/foobar/nupic.cpp/src/nupic/types/BasicType.cpp:584:29: error: catching polymorphic type ‘class nupic::Exception’ by value [-Werror=catch-value=]
   } catch (nupic::Exception e) {
                             ^
/home/dm/foobar/nupic.cpp/src/nupic/types/BasicType.cpp:587:27: error: catching polymorphic type ‘class std::exception’ by value [-Werror=catch-value=]
   } catch (std::exception e) {
                           ^
cc1plus: all warnings being treated as errors
```