### PR TITLE
SP Cleanup: Use only sp.avgConnectedSpanForColumnND

### DIFF
--- a/src/nupic/algorithms/SpatialPooler.hpp
+++ b/src/nupic/algorithms/SpatialPooler.hpp
@@ -1057,26 +1057,6 @@ public:
   Real avgColumnsPerInput_() const;
 
   /**
-      The range of connected synapses for column. This is used to
-      calculate the inhibition radius. This variation of the function only
-      supports a 1 dimensional column topology.
-
-      @param column An int number identifying a column in the permanence,
-     potential and connectivity matrices.
-  */
-  Real avgConnectedSpanForColumn1D_(UInt column) const;
-
-  /**
-      The range of connectedSynapses per column, averaged for each dimension.
-      This vaule is used to calculate the inhibition radius. This variation of
-      the  function only supports a 2 dimensional column topology.
-
-      @param column An int number identifying a column in the permanence,
-     potential and connectivity matrices.
-  */
-  Real avgConnectedSpanForColumn2D_(UInt column) const;
-
-  /**
       The range of connectedSynapses per column, averaged for each dimension.
       This vaule is used to calculate the inhibition radius. This variation of
       the function supports arbitrary column dimensions.

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -618,7 +618,7 @@ TEST(SpatialPoolerTest, testAvgConnectedSpanForColumn1D) {
 
   for (UInt i = 0; i < numColumns; i++) {
     sp.setPermanence(i, permArr[i]);
-    UInt result = sp.avgConnectedSpanForColumn1D_(i);
+    UInt result = sp.avgConnectedSpanForColumnND_(i);
     ASSERT_TRUE(result == trueAvgConnectedSpan[i]);
   }
 }
@@ -663,7 +663,7 @@ TEST(SpatialPoolerTest, testAvgConnectedSpanForColumn2D) {
 
   for (UInt i = 0; i < numColumns; i++) {
     sp.setPermanence(i, permArr1[i]);
-    UInt result = sp.avgConnectedSpanForColumn2D_(i);
+    UInt result = sp.avgConnectedSpanForColumnND_(i);
     ASSERT_TRUE(result == (trueAvgConnectedSpan1[i]));
   }
 
@@ -690,7 +690,7 @@ TEST(SpatialPoolerTest, testAvgConnectedSpanForColumn2D) {
 
   for (UInt i = 0; i < numColumns; i++) {
     sp.setPermanence(i, permArr2[i]);
-    UInt result = sp.avgConnectedSpanForColumn2D_(i);
+    UInt result = sp.avgConnectedSpanForColumnND_(i);
     ASSERT_TRUE(result == (trueAvgConnectedSpan2[i] + 1) / 2);
   }
 }


### PR DESCRIPTION
Removed code for 1D & 2D coordinate conversion and avgConnectedSpan.  Use the more general purpose N-dimsensional code instead.