### PR TITLE
Fix encoder outputtype to UInt, avoids conversions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -272,7 +272,6 @@ set(src_nupiccore_srcs
     nupic/algorithms/SpatialPooler.cpp
     nupic/algorithms/TemporalMemory.cpp
     nupic/encoders/ScalarEncoder.cpp
-    nupic/encoders/ScalarSensor.cpp
     nupic/engine/Collections.cpp
     nupic/engine/Input.cpp
     nupic/engine/Link.cpp
@@ -311,6 +310,7 @@ set(src_nupiccore_srcs
     nupic/os/Regex.cpp
     nupic/os/Timer.cpp
     nupic/regions/PyRegion.cpp
+    nupic/regions/ScalarSensor.cpp
     nupic/regions/VectorFile.cpp
     nupic/regions/VectorFileEffector.cpp
     nupic/regions/VectorFileSensor.cpp

--- a/src/nupic/encoders/ScalarEncoder.cpp
+++ b/src/nupic/encoders/ScalarEncoder.cpp
@@ -24,8 +24,8 @@
  * Implementations of the ScalarEncoder and PeriodicScalarEncoder
  */
 
+#include <algorithm> //std::fill
 #include <cmath>
-#include <cstring> // memset
 
 #include <nupic/encoders/ScalarEncoder.hpp>
 
@@ -82,10 +82,8 @@ int ScalarEncoder::encodeIntoArray(Real input, UInt output[]) {
   const int iBucket = round((input - minValue_) / bucketWidth_);
   const int firstBit = iBucket;
 
-  memset(output, 0, n_ * sizeof(output[0])); //TODO use std::fill
-  for (int i = 0; i < w_; i++) {
-    output[firstBit + i] = 1;
-  }
+  std::fill(&output[0], &output[n_ -1], 0);
+  std::fill_n(&output[firstBit], w_, 1);
   return iBucket;
 }
 
@@ -122,7 +120,7 @@ int PeriodicScalarEncoder::encodeIntoArray(Real input, UInt output[]) {
   const int left = floor(reach);
   const int right = ceil(reach);
 
-  memset(output, 0, n_ * sizeof(output[0]));
+  std::fill(&output[0], &output[n_ -1], 0);
   output[middleBit] = 1;
   for (int i = 1; i <= left; i++) {
     const int index = middleBit - i;

--- a/src/nupic/encoders/ScalarEncoder.cpp
+++ b/src/nupic/encoders/ScalarEncoder.cpp
@@ -30,6 +30,7 @@
 #include <nupic/utils/Log.hpp>
 
 namespace nupic {
+
 ScalarEncoder::ScalarEncoder(int w, double minValue, double maxValue, int n,
                              double radius, double resolution, bool clipInput)
     : w_(w), minValue_(minValue), maxValue_(maxValue), clipInput_(clipInput) {
@@ -72,7 +73,9 @@ ScalarEncoder::ScalarEncoder(int w, double minValue, double maxValue, int n,
 }
 
 
-int ScalarEncoder::encodeIntoArray(Real64 input, UInt output[]) {
+ScalarEncoder::~ScalarEncoder() {}
+
+int ScalarEncoder::encodeIntoArray(Real input, UInt output[]) {
   if (input < minValue_) {
     if (clipInput_) {
       input = minValue_;
@@ -140,6 +143,8 @@ PeriodicScalarEncoder::PeriodicScalarEncoder(int w, double minValue,
   }
 }
 
+PeriodicScalarEncoder::~PeriodicScalarEncoder() {}
+
 std::vector<UInt> ScalarEncoderBase::encode(Real input)
 {
     std::vector<UInt> output(getOutputWidth());
@@ -148,7 +153,7 @@ std::vector<UInt> ScalarEncoderBase::encode(Real input)
 }
 
 
-int PeriodicScalarEncoder::encodeIntoArray(Real64 input, UInt output[]) {
+int PeriodicScalarEncoder::encodeIntoArray(Real input, UInt output[]) {
   if (input < minValue_ || input >= maxValue_) {
     NTA_THROW << "input " << input << " not within range [" << minValue_ << ", "
               << maxValue_ << ")";

--- a/src/nupic/encoders/ScalarEncoder.cpp
+++ b/src/nupic/encoders/ScalarEncoder.cpp
@@ -71,9 +71,8 @@ ScalarEncoder::ScalarEncoder(int w, double minValue, double maxValue, int n,
   }
 }
 
-ScalarEncoder::~ScalarEncoder() {}
 
-int ScalarEncoder::encodeIntoArray(Real64 input, Real32 output[]) {
+int ScalarEncoder::encodeIntoArray(Real64 input, UInt output[]) {
   if (input < minValue_) {
     if (clipInput_) {
       input = minValue_;
@@ -98,9 +97,9 @@ int ScalarEncoder::encodeIntoArray(Real64 input, Real32 output[]) {
   for (int i = 0; i < w_; i++) {
     output[firstBit + i] = 1;
   }
-
   return iBucket;
 }
+
 
 PeriodicScalarEncoder::PeriodicScalarEncoder(int w, double minValue,
                                              double maxValue, int n,
@@ -141,9 +140,15 @@ PeriodicScalarEncoder::PeriodicScalarEncoder(int w, double minValue,
   }
 }
 
-PeriodicScalarEncoder::~PeriodicScalarEncoder() {}
+std::vector<UInt> ScalarEncoderBase::encode(Real input)
+{
+    std::vector<UInt> output(getOutputWidth());
+    encodeIntoArray(input, output.data());
+    return output;
+}
 
-int PeriodicScalarEncoder::encodeIntoArray(Real64 input, Real32 output[]) {
+
+int PeriodicScalarEncoder::encodeIntoArray(Real64 input, UInt output[]) {
   if (input < minValue_ || input >= maxValue_) {
     NTA_THROW << "input " << input << " not within range [" << minValue_ << ", "
               << maxValue_ << ")";

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -71,7 +71,7 @@ namespace nupic {
     ScalarEncoderBase(int w, int n):
 	 w_(w), n_(n) {
       NTA_CHECK(w > 0) << "EncoderBase: w must be > 0";
-      NTA_CHECK(w < n) << "EncoderBase: w must be < n";
+//      NTA_CHECK(w < n) << "EncoderBase: w must be < n"; //not, because we can init with n=0 and eg resolution
     }
 
   protected:

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include <nupic/types/Types.hpp>
+#include <nupic/utils/Log.hpp> //NTA_CHECK
 
 namespace nupic {
 /**
@@ -39,8 +40,7 @@ namespace nupic {
   class ScalarEncoderBase
   {
   public:
-    virtual ~ScalarEncoderBase()
-      {}
+    virtual ~ScalarEncoderBase() {}
 
     /**
      * Encodes input, puts the encoded binary value into output, and returns the a
@@ -59,13 +59,24 @@ namespace nupic {
     /**
      * Returns the output width, in bits.
      */
-    virtual UInt getOutputWidth() const = 0;
+    UInt getOutputWidth() const { return n_; };
 
     /**
      * public wrapper method for the encodeIntoArray()
      * @return binary representation of the input
      */
     std::vector<UInt> encode(Real input);
+
+  protected: 
+    ScalarEncoderBase(int w, int n):
+	 w_(w), n_(n) {
+      NTA_CHECK(w > 0) << "EncoderBase: w must be > 0";
+      NTA_CHECK(w < n) << "EncoderBase: w must be < n";
+    }
+
+  protected:
+    const int w_;
+    int n_;
   };
 
 /** Encodes a floating point number as a contiguous block of 1s.
@@ -113,17 +124,14 @@ public:
    */
   ScalarEncoder(int w, double minValue, double maxValue, int n, double radius,
                 double resolution, bool clipInput);
-  ~ScalarEncoder() override;
 
-    virtual int encodeIntoArray(Real input, UInt output[]) override;
-    virtual UInt getOutputWidth() const override { return n_; }
+  int encodeIntoArray(Real input, UInt output[]) override;
 
-private:
-  int w_;
-  int n_;
+protected:
   double minValue_;
   double maxValue_;
   double bucketWidth_;
+private:
   bool clipInput_;
 }; // end class ScalarEncoder
 
@@ -145,7 +153,7 @@ private:
  * bucket and 1.51 in the second, the PeriodicScalarEncoder will put 1.99 in
  * the first bucket and 2.0 in the second.
  */
-class PeriodicScalarEncoder : public ScalarEncoderBase {
+class PeriodicScalarEncoder : public ScalarEncoder {
 public:
   /**
    * Constructs a PeriodicScalarEncoder
@@ -170,17 +178,9 @@ public:
    */
   PeriodicScalarEncoder(int w, double minValue, double maxValue, int n,
                         double radius, double resolution);
-  virtual ~PeriodicScalarEncoder() override;
 
-    virtual int encodeIntoArray(Real input, UInt output[]) override;
-    virtual UInt getOutputWidth() const override { return n_; }
+  int encodeIntoArray(Real input, UInt output[]) override;
 
-private:
-  int w_;
-  int n_;
-  double minValue_;
-  double maxValue_;
-  double bucketWidth_;
 }; // end class PeriodicScalarEncoder
 } // end namespace nupic
 

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -54,7 +54,7 @@ public:
   /**
    * Returns the output width, in bits.
    */
-  virtual int getOutputWidth() const = 0;
+  virtual UInt getOutputWidth() const = 0;
 };
 
 /** Encodes a floating point number as a contiguous block of 1s.
@@ -105,7 +105,7 @@ public:
   ~ScalarEncoder() override;
 
   virtual int encodeIntoArray(Real64 input, Real32 output[]) override;
-  virtual int getOutputWidth() const override { return n_; }
+  virtual UInt getOutputWidth() const override { return n_; }
 
 private:
   int w_;
@@ -162,7 +162,7 @@ public:
   virtual ~PeriodicScalarEncoder() override;
 
   virtual int encodeIntoArray(Real64 input, Real32 output[]) override;
-  virtual int getOutputWidth() const override { return n_; }
+  virtual UInt getOutputWidth() const override { return n_; }
 
 private:
   int w_;

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -27,6 +27,8 @@
 #ifndef NTA_ENCODERS_SCALAR
 #define NTA_ENCODERS_SCALAR
 
+#include <vector>
+
 #include <nupic/types/Types.hpp>
 
 namespace nupic {
@@ -34,28 +36,37 @@ namespace nupic {
  * @b Description
  * Base class for ScalarEncoders
  */
-class ScalarEncoderBase {
-public:
-  virtual ~ScalarEncoderBase() {}
+  class ScalarEncoderBase
+  {
+  public:
+    virtual ~ScalarEncoderBase()
+      {}
 
-  /**
-   * Encodes input, puts the encoded value into output, and returns the a
-   * bucket number for the encoding.
-   *
-   * The bucket number is essentially the input encoded into an integer rather
-   * than an array. A bucket number is easier to "decode" or to use inside a
-   * classifier.
-   *
-   * @param input The value to encode
-   * @param output Should have length of at least getOutputWidth()
-   */
-  virtual int encodeIntoArray(Real64 input, Real32 output[]) = 0;
+    /**
+     * Encodes input, puts the encoded binary value into output, and returns the a
+     * bucket number for the encoding.
+     *
+     * The bucket number is essentially the input encoded into an integer rather
+     * than an array. A bucket number is easier to "decode" or to use inside a
+     * classifier.
+     *
+     * @param input The value to encode (Real)
+     * @param output Should have length of at least getOutputWidth(), binary output, (UInt[])
+     * @return id of bin where assigned (int)
+     */
+    virtual int encodeIntoArray(Real input, UInt output[]) = 0;
 
-  /**
-   * Returns the output width, in bits.
-   */
-  virtual UInt getOutputWidth() const = 0;
-};
+    /**
+     * Returns the output width, in bits.
+     */
+    virtual UInt getOutputWidth() const = 0;
+
+    /**
+     * public wrapper method for the encodeIntoArray()
+     * @return binary representation of the input
+     */
+    std::vector<UInt> encode(Real input);
+  };
 
 /** Encodes a floating point number as a contiguous block of 1s.
  *
@@ -104,8 +115,8 @@ public:
                 double resolution, bool clipInput);
   ~ScalarEncoder() override;
 
-  virtual int encodeIntoArray(Real64 input, Real32 output[]) override;
-  virtual UInt getOutputWidth() const override { return n_; }
+    virtual int encodeIntoArray(Real input, UInt output[]) override;
+    virtual UInt getOutputWidth() const override { return n_; }
 
 private:
   int w_;
@@ -161,8 +172,8 @@ public:
                         double radius, double resolution);
   virtual ~PeriodicScalarEncoder() override;
 
-  virtual int encodeIntoArray(Real64 input, Real32 output[]) override;
-  virtual UInt getOutputWidth() const override { return n_; }
+    virtual int encodeIntoArray(Real input, UInt output[]) override;
+    virtual UInt getOutputWidth() const override { return n_; }
 
 private:
   int w_;

--- a/src/nupic/encoders/ScalarSensor.cpp
+++ b/src/nupic/encoders/ScalarSensor.cpp
@@ -104,12 +104,12 @@ ScalarSensor::ScalarSensor(BundleIO &bundle, Region *region)
   {
     Real32* array = (Real32*)encodedOutput_->getData().getBuffer();
     UInt uintArray[encoder_->getOutputWidth()];
-    for(UInt i=0; i<encoder_->getOutputWidth(); i++) //FIXME optimize
-    {
-      uintArray[i] = (UInt)array[i];
-    }
     const Int32 iBucket = encoder_->encodeIntoArray(sensedValue_, uintArray);
     ((Int32*)bucketOutput_->getData().getBuffer())[0] = iBucket;
+    for(UInt i=0; i<encoder_->getOutputWidth(); i++) //FIXME optimize
+    {
+      array[i] = (Real32)uintArray[i]; // copy values back to SP's 'array' array
+    }
   }
 
 ScalarSensor::~ScalarSensor() { delete encoder_; }

--- a/src/nupic/encoders/ScalarSensor.cpp
+++ b/src/nupic/encoders/ScalarSensor.cpp
@@ -39,40 +39,6 @@
 #include <nupic/utils/Log.hpp>
 
 
-namespace nupic
-{
-  ScalarSensor::ScalarSensor(const ValueMap& params, Region *region)
-    : RegionImpl(region)
-  {
-    const UInt32 n = params.getScalarT<UInt32>("n");
-    const UInt32 w = params.getScalarT<UInt32>("w");
-    const Real64 resolution = params.getScalarT<Real64>("resolution");
-    const Real64 radius = params.getScalarT<Real64>("radius");
-    const Real64 minValue = params.getScalarT<Real64>("minValue");
-    const Real64 maxValue = params.getScalarT<Real64>("maxValue");
-    const bool periodic = params.getScalarT<bool>("periodic");
-    const bool clipInput = params.getScalarT<bool>("clipInput");
-    if (periodic)
-    {
-      encoder_ = new PeriodicScalarEncoder(w, minValue, maxValue, n, radius,
-                                           resolution);
-    }
-    else
-    {
-      encoder_ = new ScalarEncoder(w, minValue, maxValue, n, radius, resolution,
-                                   clipInput);
-    }
-
-    sensedValue_ = params.getScalarT<Real>("sensedValue");
-  }
-
-  ScalarSensor::ScalarSensor(BundleIO& bundle, Region* region) :
-    RegionImpl(region)
-  {
-    deserialize(bundle);
-  }
-
-
 namespace nupic {
 ScalarSensor::ScalarSensor(const ValueMap &params, Region *region)
     : RegionImpl(region) {

--- a/src/nupic/engine/RegionImplFactory.cpp
+++ b/src/nupic/engine/RegionImplFactory.cpp
@@ -23,7 +23,7 @@
 #include <stdexcept>
 
 
-#include <nupic/encoders/ScalarSensor.hpp>
+#include <nupic/regions/ScalarSensor.hpp>
 #include <nupic/engine/Region.hpp>
 #include <nupic/engine/RegionImpl.hpp>
 #include <nupic/engine/RegionImplFactory.hpp>

--- a/src/nupic/os/Timer.hpp
+++ b/src/nupic/os/Timer.hpp
@@ -88,6 +88,9 @@ public:
 
   std::string toString() const;
 
+  // empirically estimate relative performance of the machine (HW, current load)
+  static Real getSpeed();
+
 private:
   typedef std::chrono::high_resolution_clock my_clock;
   my_clock::time_point start_time_;
@@ -99,6 +102,8 @@ private:
   bool started_;       // true if was started
 
 }; // class Timer
+
+static Real SPEED = -1; //uninitialized, for getSpeed() 
 
 } // namespace nupic
 

--- a/src/nupic/regions/ScalarSensor.cpp
+++ b/src/nupic/regions/ScalarSensor.cpp
@@ -157,7 +157,7 @@ ScalarSensor::~ScalarSensor() { delete encoder_; }
 
   /* ----- outputs ----- */
 
-  ns->outputs.add("encoded", OutputSpec("Encoded value", NTA_BasicType_Real32,
+  ns->outputs.add("encoded", OutputSpec("Encoded value", NTA_BasicType_UInt32,
                                         0,    // elementCount
                                         true, // isRegionLevel
                                         true  // isDefaultOutput

--- a/src/nupic/regions/ScalarSensor.cpp
+++ b/src/nupic/regions/ScalarSensor.cpp
@@ -24,10 +24,8 @@
  * Implementation of the ScalarSensor
  */
 
-#include <string>
+#include <nupic/regions/ScalarSensor.hpp>
 
-
-#include <nupic/encoders/ScalarSensor.hpp>
 #include <nupic/engine/Input.hpp>
 #include <nupic/engine/Output.hpp>
 #include <nupic/engine/Region.hpp>
@@ -35,11 +33,11 @@
 #include <nupic/ntypes/Array.hpp>
 #include <nupic/ntypes/BundleIO.hpp>
 #include <nupic/ntypes/ObjectModel.hpp> // IWrite/ReadBuffer
-#include <nupic/ntypes/Value.hpp>
 #include <nupic/utils/Log.hpp>
 
 
 namespace nupic {
+
 ScalarSensor::ScalarSensor(const ValueMap &params, Region *region)
     : RegionImpl(region) {
   const UInt32 n = params.getScalarT<UInt32>("n");

--- a/src/nupic/regions/ScalarSensor.hpp
+++ b/src/nupic/regions/ScalarSensor.hpp
@@ -30,7 +30,6 @@
 #include <string>
 #include <vector>
 
-
 #include <nupic/encoders/ScalarEncoder.hpp>
 #include <nupic/engine/RegionImpl.hpp>
 #include <nupic/ntypes/Value.hpp>

--- a/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
@@ -28,7 +28,6 @@
 
 #include <fstream>
 #include <iostream>
-#include <cmath> //for sin
 
 #include <nupic/algorithms/Connections.hpp>
 #include <nupic/algorithms/TemporalMemory.hpp>
@@ -248,35 +247,6 @@ vector<CellIdx> _computeSPWinnerCells(Connections &connections, UInt numCells,
   return vector<CellIdx>(winnerCells.begin(), winnerCells.end());
 }
 
-float _SPEED = -1;
-/**
- * estimate speed (CPU & load) of the current system.
- * Tests must perform relative to this value
- */
-float getSpeed() {
-  if (_SPEED == -1) {
-    Timer t(true);
-    //this code just wastes CPU time to estimate speed
-    vector<Real> data(10000000);
-    for(Size i=0; i<data.size(); i++) {
-      data[i]=(Real)rng.getUInt32(80085);
-      auto t = data[i];
-      data[i] = data[data.size()-i];
-      data[data.size()-i]=t;
-    }
-    rng.shuffle(begin(data), end(data));
-    vector<Real> sins;
-    for (auto d : data) {
-      sins.push_back(sin(d)/cos(d));
-    }
-    data = rng.sample<Real>(sins, 666);
-    NTA_CHECK(data.size() == 666);
-    t.stop();
-    _SPEED = max(1.0, t.getElapsed());
-
-  }
-  return _SPEED;
-}
 
 
 // TESTS
@@ -296,7 +266,7 @@ const UInt COLS = 2048; //standard num of columns in SP/TM
  */
 TEST(ConnectionsPerformanceTest, testTM) {
 	auto tim = runTemporalMemoryTest(COLS, 40, EPOCHS, SEQ, "temporal memory");
-	ASSERT_LE(tim, 1.0*getSpeed()); //there are times, we must be better. Bit underestimated for slow CI
+	ASSERT_LE(tim, 1.0*Timer::getSpeed()); //there are times, we must be better. Bit underestimated for slow CI
 }
 
 /**
@@ -304,7 +274,7 @@ TEST(ConnectionsPerformanceTest, testTM) {
  */
 TEST(ConnectionsPerformanceTest, testTMLarge) {
   auto tim = runTemporalMemoryTest(2*COLS, 328, EPOCHS/2, SEQ, "temporal memory (large)");
-  ASSERT_LE(tim, 1.9*getSpeed());
+  ASSERT_LE(tim, 1.9*Timer::getSpeed());
 }
 
 /**
@@ -313,7 +283,7 @@ TEST(ConnectionsPerformanceTest, testTMLarge) {
 TEST(ConnectionsPerformanceTest, testSP) {
   auto tim = runSpatialPoolerTest(COLS, COLS, EPOCHS, SEQ, "spatial pooler");
 #ifdef NDEBUG
-  ASSERT_LE(tim, 5.3*getSpeed());
+  ASSERT_LE(tim, 5.3*Timer::getSpeed());
 #endif
 }
 
@@ -323,7 +293,7 @@ TEST(ConnectionsPerformanceTest, testSP) {
 TEST(ConnectionsPerformanceTest, testTP) {
   auto tim = runSpatialPoolerTest(COLS, 16384, EPOCHS/4, SEQ/25, "temporal pooler");
 #ifdef NDEBUG
-  ASSERT_LE(tim, 10.8*getSpeed());
+  ASSERT_LE(tim, 10.8*Timer::getSpeed());
 #endif
 }
 

--- a/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
@@ -279,10 +279,13 @@ float getSpeed() {
 }
 
 
-#ifdef NDEBUG //disable performance tests in debug mode
 // TESTS
 const UInt SEQ = 100; //number of sequences ran in tests
-const UInt EPOCHS = 20; //epochs tests run
+#ifdef NDEBUG
+  const UInt EPOCHS = 20; //only short in debug; is epochs/2 in some tests, that's why 4
+#else
+  const UInt EPOCHS = 4; //epochs tests run
+#endif
 const UInt COLS = 2048; //standard num of columns in SP/TM
 
 
@@ -299,7 +302,7 @@ TEST(ConnectionsPerformanceTest, testTM) {
  * Tests typical usage of Connections with a large Temporal Memory.
  */
 TEST(ConnectionsPerformanceTest, testTMLarge) {
-  auto tim = runTemporalMemoryTest(2*COLS, 328, 10, SEQ, "temporal memory (large)");
+  auto tim = runTemporalMemoryTest(2*COLS, 328, EPOCHS/2, SEQ, "temporal memory (large)");
   ASSERT_LE(tim, 3.8*getSpeed());
 }
 
@@ -318,6 +321,5 @@ TEST(ConnectionsPerformanceTest, testTP) {
   auto tim = runSpatialPoolerTest(COLS, 16384, EPOCHS/2, SEQ/50, "temporal pooler");
   ASSERT_LE(tim, 13.0*getSpeed());
 }
-#endif //DEBUG
 
 } // end namespace

--- a/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
@@ -284,6 +284,8 @@ TEST(ConnectionsPerformanceTest, testSP) {
   auto tim = runSpatialPoolerTest(COLS, COLS, EPOCHS, SEQ, "spatial pooler");
 #ifdef NDEBUG
   ASSERT_LE(tim, 5.3*Timer::getSpeed());
+#else
+  cout << tim << endl; //to avoid unused variable error
 #endif
 }
 
@@ -294,6 +296,8 @@ TEST(ConnectionsPerformanceTest, testTP) {
   auto tim = runSpatialPoolerTest(COLS, 16384, EPOCHS/4, SEQ/25, "temporal pooler");
 #ifdef NDEBUG
   ASSERT_LE(tim, 10.8*Timer::getSpeed());
+#else
+  cout << tim << endl; //to avoid unused variable error
 #endif
 }
 

--- a/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
@@ -280,11 +280,14 @@ TEST(ConnectionsPerformanceTest, testTMLarge) {
 /**
  * Tests typical usage of Connections with Spatial Pooler.
  */
+#define UNUSED(x) (void)(x)
+
 TEST(ConnectionsPerformanceTest, testSP) {
   auto tim = runSpatialPoolerTest(COLS, COLS, EPOCHS, SEQ, "spatial pooler");
 #ifdef NDEBUG
   ASSERT_LE(tim, 5.3*Timer::getSpeed());
 #endif
+  UNUSED(tim);
 }
 
 /**
@@ -295,6 +298,7 @@ TEST(ConnectionsPerformanceTest, testTP) {
 #ifdef NDEBUG
   ASSERT_LE(tim, 10.8*Timer::getSpeed());
 #endif
+  UNUSED(tim);
 }
 
 } // end namespace

--- a/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
@@ -284,8 +284,6 @@ TEST(ConnectionsPerformanceTest, testSP) {
   auto tim = runSpatialPoolerTest(COLS, COLS, EPOCHS, SEQ, "spatial pooler");
 #ifdef NDEBUG
   ASSERT_LE(tim, 5.3*Timer::getSpeed());
-#else
-  cout << tim << endl; //to avoid unused variable error
 #endif
 }
 
@@ -296,8 +294,6 @@ TEST(ConnectionsPerformanceTest, testTP) {
   auto tim = runSpatialPoolerTest(COLS, 16384, EPOCHS/4, SEQ/25, "temporal pooler");
 #ifdef NDEBUG
   ASSERT_LE(tim, 10.8*Timer::getSpeed());
-#else
-  cout << tim << endl; //to avoid unused variable error
 #endif
 }
 

--- a/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
@@ -280,11 +280,11 @@ float getSpeed() {
 
 
 // TESTS
-const UInt SEQ = 100; //number of sequences ran in tests
+const UInt SEQ = 50; //number of sequences ran in tests
 #ifdef NDEBUG
-  const UInt EPOCHS = 20; //only short in debug; is epochs/2 in some tests, that's why 4
+  const UInt EPOCHS = 20; //tests run for epochs times
 #else
-  const UInt EPOCHS = 4; //epochs tests run
+  const UInt EPOCHS = 8; //only short in debug; is epochs/2 in some tests, that's why 4
 #endif
 const UInt COLS = 2048; //standard num of columns in SP/TM
 
@@ -295,7 +295,7 @@ const UInt COLS = 2048; //standard num of columns in SP/TM
  */
 TEST(ConnectionsPerformanceTest, testTM) {
 	auto tim = runTemporalMemoryTest(COLS, 40, EPOCHS, SEQ, "temporal memory");
-	ASSERT_LE(tim, 2.0*getSpeed()); //there are times, we must be better. Bit underestimated for slow CI
+	ASSERT_LE(tim, 1.0*getSpeed()); //there are times, we must be better. Bit underestimated for slow CI
 }
 
 /**
@@ -303,7 +303,7 @@ TEST(ConnectionsPerformanceTest, testTM) {
  */
 TEST(ConnectionsPerformanceTest, testTMLarge) {
   auto tim = runTemporalMemoryTest(2*COLS, 328, EPOCHS/2, SEQ, "temporal memory (large)");
-  ASSERT_LE(tim, 3.8*getSpeed());
+  ASSERT_LE(tim, 1.9*getSpeed());
 }
 
 /**
@@ -311,15 +311,15 @@ TEST(ConnectionsPerformanceTest, testTMLarge) {
  */
 TEST(ConnectionsPerformanceTest, testSP) {
   auto tim = runSpatialPoolerTest(COLS, COLS, EPOCHS, SEQ, "spatial pooler");
-  ASSERT_LE(tim, 6.3*getSpeed());
+  ASSERT_LE(tim, 5.3*getSpeed());
 }
 
 /**
  * Tests typical usage of Connections with Temporal Pooler.
  */
 TEST(ConnectionsPerformanceTest, testTP) {
-  auto tim = runSpatialPoolerTest(COLS, 16384, EPOCHS/2, SEQ/50, "temporal pooler");
-  ASSERT_LE(tim, 13.0*getSpeed());
+  auto tim = runSpatialPoolerTest(COLS, 16384, EPOCHS/4, SEQ/25, "temporal pooler");
+  ASSERT_LE(tim, 10.8*getSpeed());
 }
 
 } // end namespace

--- a/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
@@ -280,11 +280,12 @@ float getSpeed() {
 
 
 // TESTS
-const UInt SEQ = 50; //number of sequences ran in tests
 #ifdef NDEBUG
+  const UInt SEQ = 50; //number of sequences ran in tests
   const UInt EPOCHS = 20; //tests run for epochs times
 #else
-  const UInt EPOCHS = 8; //only short in debug; is epochs/2 in some tests, that's why 4
+  const UInt SEQ = 25; //number of sequences ran in tests
+  const UInt EPOCHS = 4; //only short in debug; is epochs/2 in some tests, that's why 4
 #endif
 const UInt COLS = 2048; //standard num of columns in SP/TM
 
@@ -311,7 +312,9 @@ TEST(ConnectionsPerformanceTest, testTMLarge) {
  */
 TEST(ConnectionsPerformanceTest, testSP) {
   auto tim = runSpatialPoolerTest(COLS, COLS, EPOCHS, SEQ, "spatial pooler");
+#ifdef NDEBUG
   ASSERT_LE(tim, 5.3*getSpeed());
+#endif
 }
 
 /**
@@ -319,7 +322,9 @@ TEST(ConnectionsPerformanceTest, testSP) {
  */
 TEST(ConnectionsPerformanceTest, testTP) {
   auto tim = runSpatialPoolerTest(COLS, 16384, EPOCHS/4, SEQ/25, "temporal pooler");
+#ifdef NDEBUG
   ASSERT_LE(tim, 10.8*getSpeed());
+#endif
 }
 
 } // end namespace

--- a/src/test/unit/algorithms/HelloSPTPTest.cpp
+++ b/src/test/unit/algorithms/HelloSPTPTest.cpp
@@ -47,7 +47,7 @@ TEST(HelloSPTPTest, performance) {
 
   const UInt COLS = 2048; // number of columns in SP, TP
   const UInt DIM_INPUT = 10000;
-  const UInt CELLS = 8; // cells per column in TP
+  const UInt CELLS = 10; // cells per column in TP
 #ifdef NDEBUG
   const UInt EPOCHS = 1000; // number of iterations (calls to SP/TP compute() )
 #else
@@ -58,6 +58,7 @@ TEST(HelloSPTPTest, performance) {
   std::cout << "EPOCHS = " << EPOCHS << std::endl;
 
   // generate random input
+  vector<UInt> input(DIM_INPUT, 0);
   ScalarEncoder enc(1337/*w*/, -1000.0, 1000.1, (int)DIM_INPUT/*n*/, 0.0, 0.0, false);
   vector<UInt> outSP(COLS); // active array, output of SP/TP
 
@@ -79,11 +80,13 @@ TEST(HelloSPTPTest, performance) {
   //run
   for (UInt e = 0; e < EPOCHS; e++) {
     const Real val = rnd.getUInt32(1000)-(rnd.getUInt32(1000)*rnd.getReal64());
-    const auto input = enc.encode(val); 
+    //enc
+    enc.encodeIntoArray(val, input.data()); 
+    //SP
     fill(outSP.begin(), outSP.end(), 0);
     EXPECT_NO_THROW(sp.compute(input.data(), true, outSP.data()));
     sp.stripUnlearnedColumns(outSP.data());
-
+    //TP
     rIn = VectorHelpers::castVectorType<UInt, Real>(outSP);
     EXPECT_NO_THROW(tp.compute(rIn.data(), rOut.data(), true, true));
     outTP = VectorHelpers::castVectorType<Real, UInt>(rOut);

--- a/src/test/unit/algorithms/HelloSPTPTest.cpp
+++ b/src/test/unit/algorithms/HelloSPTPTest.cpp
@@ -30,6 +30,8 @@
 
 #include "nupic/algorithms/Cells4.hpp"  //TODO use TM instead
 #include "nupic/algorithms/SpatialPooler.hpp"
+#include "nupic/encoders/ScalarEncoder.hpp"
+
 #include "nupic/os/Timer.hpp"
 #include "nupic/utils/VectorHelpers.hpp"
 #include "nupic/utils/Random.hpp" 
@@ -53,7 +55,7 @@ TEST(HelloSPTPTest, performance) {
   std::cout << "EPOCHS = " << EPOCHS << std::endl;
 
   // generate random input
-  vector<UInt> input(DIM_INPUT);
+  ScalarEncoder enc(1337/*w*/, -1000.0, 1000.1, (int)DIM_INPUT/*n*/, 0.0, 0.0, false);
   vector<UInt> outSP(COLS); // active array, output of SP/TP
 
   // initialize SP, TP
@@ -73,7 +75,8 @@ TEST(HelloSPTPTest, performance) {
 
   //run
   for (UInt e = 0; e < EPOCHS; e++) {
-    generate(input.begin(), input.end(), [&] () { return rnd.getUInt32(2); });
+    const Real val = rnd.getUInt32(1000)-(rnd.getUInt32(1000)*rnd.getReal64());
+    const auto input = enc.encode(val); 
     fill(outSP.begin(), outSP.end(), 0);
     EXPECT_NO_THROW(sp.compute(input.data(), true, outSP.data()));
     sp.stripUnlearnedColumns(outSP.data());

--- a/src/test/unit/algorithms/HelloSPTPTest.cpp
+++ b/src/test/unit/algorithms/HelloSPTPTest.cpp
@@ -23,7 +23,6 @@
 #include "gtest/gtest.h"
 
 #include <algorithm> // std::generate
-#include <cmath>     // pow
 #include <ctime>     // std::time
 #include <iostream>
 #include <vector>
@@ -48,8 +47,12 @@ TEST(HelloSPTPTest, performance) {
 
   const UInt COLS = 2048; // number of columns in SP, TP
   const UInt DIM_INPUT = 10000;
-  const UInt CELLS = 10; // cells per column in TP
-  const UInt EPOCHS = (UInt)pow(10, 3); // number of iterations (calls to SP/TP compute() )
+  const UInt CELLS = 8; // cells per column in TP
+#ifdef NDEBUG
+  const UInt EPOCHS = 1000; // number of iterations (calls to SP/TP compute() )
+#else
+  const UInt EPOCHS = 3; //run only short test in debug
+#endif
   std::cout << "starting test. DIM_INPUT=" << DIM_INPUT
   		<< ", DIM=" << COLS << ", CELLS=" << CELLS << std::endl;
   std::cout << "EPOCHS = " << EPOCHS << std::endl;

--- a/src/test/unit/algorithms/HelloSPTPTest.cpp
+++ b/src/test/unit/algorithms/HelloSPTPTest.cpp
@@ -23,7 +23,6 @@
 #include "gtest/gtest.h"
 
 #include <algorithm> // std::generate
-#include <ctime>     // std::time
 #include <iostream>
 #include <vector>
 
@@ -103,7 +102,7 @@ TEST(HelloSPTPTest, performance) {
 
   stopwatch.stop();
   const size_t timeTotal = stopwatch.getElapsed();
-  const size_t CI_avg_time = 11; //sec
+  const size_t CI_avg_time = 11*Timer::getSpeed(); //sec
   cout << "Total elapsed time = " << timeTotal << " seconds" << endl;
   EXPECT_TRUE(timeTotal <= CI_avg_time) << //we'll see how stable the time result in CI is, if usable
 	  "HelloSPTP test slower than expected! (" << timeTotal << ",should be "<< CI_avg_time;

--- a/src/test/unit/algorithms/HelloSPTPTest.cpp
+++ b/src/test/unit/algorithms/HelloSPTPTest.cpp
@@ -103,7 +103,7 @@ TEST(HelloSPTPTest, performance) {
 
   stopwatch.stop();
   const size_t timeTotal = stopwatch.getElapsed();
-  const size_t CI_avg_time = 45; //sec
+  const size_t CI_avg_time = 11; //sec
   cout << "Total elapsed time = " << timeTotal << " seconds" << endl;
   EXPECT_TRUE(timeTotal <= CI_avg_time) << //we'll see how stable the time result in CI is, if usable
 	  "HelloSPTP test slower than expected! (" << timeTotal << ",should be "<< CI_avg_time;

--- a/src/test/unit/encoders/ScalarEncoderTest.cpp
+++ b/src/test/unit/encoders/ScalarEncoderTest.cpp
@@ -57,20 +57,23 @@ std::vector<Real32> patternFromNZ(int n, std::vector<size_t> patternNZ) {
   return v;
 }
 
-void doScalarValueCases(ScalarEncoderBase &e,
-                        std::vector<ScalarValueCase> cases) {
-  for (auto c = cases.begin(); c != cases.end(); c++) {
-    auto actualOutput = getEncoding(e, c->input);
-    for (int i = 0; i < e.getOutputWidth(); i++) {
-      EXPECT_EQ(c->expectedOutput[i], actualOutput[i])
-          << "For input " << c->input << " and index " << i << std::endl
-          << "EXPECTED:" << std::endl
-          << vec2str(c->expectedOutput) << std::endl
-          << "ACTUAL:" << std::endl
-          << vec2str(actualOutput);
+void doScalarValueCases(ScalarEncoderBase& e, std::vector<ScalarValueCase> cases)
+{
+  for (auto c = cases.begin(); c != cases.end(); c++)
+    {
+      auto actualOutput = getEncoding(e, c->input);
+      for (UInt i = 0; i < e.getOutputWidth(); i++)
+        {
+          EXPECT_EQ(c->expectedOutput[i], actualOutput[i])
+            << "For input " << c->input << " and index " << i << std::endl
+            << "EXPECTED:" << std::endl
+            << vec2str(c->expectedOutput) << std::endl
+            << "ACTUAL:" << std::endl
+            << vec2str(actualOutput);
+        }
     }
-  }
 }
+
 
 TEST(ScalarEncoder, ValidScalarInputs) {
   const int n = 10;

--- a/src/test/unit/encoders/ScalarEncoderTest.cpp
+++ b/src/test/unit/encoders/ScalarEncoderTest.cpp
@@ -33,27 +33,31 @@ using namespace nupic;
 
 template <typename T> std::string vec2str(std::vector<T> vec) {
   std::ostringstream oss("");
-  for (size_t i = 0; i < vec.size(); i++)
+  for (size_t i = 0; i < vec.size(); i++) //FIXME VectorHelper would have been used eg. here
     oss << vec[i];
   return oss.str();
 }
 
-std::vector<Real32> getEncoding(ScalarEncoderBase &e, Real64 input) {
-  auto actualOutput = std::vector<Real32>(e.getOutputWidth());
+std::vector<UInt> getEncoding(ScalarEncoderBase& e, Real input)
+{
+  auto actualOutput = std::vector<UInt>(e.getOutputWidth());
   e.encodeIntoArray(input, &actualOutput[0]);
   return actualOutput;
 }
 
-struct ScalarValueCase {
-  Real64 input;
-  std::vector<Real32> expectedOutput;
+struct ScalarValueCase
+{
+  Real input;
+  std::vector<UInt> expectedOutput;
 };
 
-std::vector<Real32> patternFromNZ(int n, std::vector<size_t> patternNZ) {
-  auto v = std::vector<Real32>(n, 0);
-  for (auto it = patternNZ.begin(); it != patternNZ.end(); it++) {
-    v[*it] = 1;
-  }
+std::vector<UInt> patternFromNZ(int n, std::vector<size_t> patternNZ)
+{
+  auto v = std::vector<UInt>(n, 0);
+  for (auto it = patternNZ.begin(); it != patternNZ.end(); it++)
+    {
+      v[*it] = 1;
+    }
   return v;
 }
 


### PR DESCRIPTION
- [x] moves ScalarSensor to regions/ where it belongs
- [x] makes PeriodicSalarEncoder extend from ScalarEnc, not EncoderBase; reduces code
- [x] cleanup encoders
- [x] change output type of encoders to UInt* (from Real*), as UInt use all other algorithms 