### PR TITLE
SP equals

### DIFF
--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -1079,11 +1079,10 @@ void SpatialPooler::save(ostream &outStream) const {
   }
   outStream << endl;
 
-  // Store matrices.
+  // Store matrices:
+  //potentials
   for (UInt i = 0; i < numColumns_; i++) {
-    vector<UInt> pot;
-    pot.resize(potentialPools_.nNonZerosOnRow(i));
-    pot = potentialPools_.getSparseRow(i);
+    const auto pot = potentialPools_.getSparseRow(i);
     outStream << pot.size() << endl;
     for (auto &elem : pot) {
       outStream << elem << " ";
@@ -1092,6 +1091,7 @@ void SpatialPooler::save(ostream &outStream) const {
   }
   outStream << endl;
 
+  //permanences
   for (UInt i = 0; i < numColumns_; i++) {
     vector<pair<UInt, Real>> perm;
     perm.resize(permanences_.nNonZerosOnRow(i));
@@ -1104,6 +1104,9 @@ void SpatialPooler::save(ostream &outStream) const {
   }
   outStream << endl;
 
+  //connected synapses get rebuilt from permanences_ updateSynapsesForColumn_(), see load()
+
+  //Random
   outStream << rng_ << endl;
 
   outStream << "~SpatialPooler" << endl;

--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -1272,3 +1272,19 @@ void SpatialPooler::printState(vector<Real> &state) {
   }
   std::cout << "]\n";
 }
+
+/** equals implementation based on serialization */
+bool SpatialPooler::operator==(const SpatialPooler& o) const{
+  stringstream s;
+  s.flags(ios::scientific);
+  s.precision(numeric_limits<double>::digits10 + 1);
+  
+  this->save(s);
+  const string thisStr = s.str();
+
+  s.str(""); //clear stream
+  o.save(s);
+  const string otherStr = s.str();
+
+  return thisStr == otherStr;
+}

--- a/src/nupic/algorithms/SpatialPooler.hpp
+++ b/src/nupic/algorithms/SpatialPooler.hpp
@@ -88,6 +88,11 @@ public:
 
   virtual ~SpatialPooler() {}
 
+  // equals operators
+  virtual bool operator==(const SpatialPooler& o) const;
+  inline bool operator!=(const SpatialPooler& o) const { return !this->operator==(o); }
+  inline bool equals(const SpatialPooler& o) const { return this->operator==(o); } //equals is for PY
+
 
   /**
   Initialize the spatial pooler using the given parameters.

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -56,7 +56,7 @@ bool almost_eq(Real a, Real b) {
   return (diff > -1e-5 && diff < 1e-5);
 }
 
-bool check_vector_eq(UInt arr[], vector<UInt> vec) {
+bool check_vector_eq(UInt arr[], vector<UInt> vec) {  //TODO replace with ArrayBase, VectorHelpers or teplates
   for (UInt i = 0; i < vec.size(); i++) {
     if (arr[i] != vec[i]) {
       return false;
@@ -116,7 +116,7 @@ bool check_vector_eq(vector<Real> vec1, vector<Real> vec2) {
   return true;
 }
 
-void check_spatial_eq(SpatialPooler sp1, SpatialPooler sp2) {
+void check_spatial_eq(const SpatialPooler& sp1, const SpatialPooler& sp2) {
   UInt numColumns = sp1.getNumColumns();
   UInt numInputs = sp2.getNumInputs();
 
@@ -2020,6 +2020,8 @@ TEST(SpatialPoolerTest, testConstructorVsInitialize) {
 
   // The two SP should be the same
   check_spatial_eq(sp1, sp2);
+  EXPECT_EQ(sp1, sp2);
+  EXPECT_TRUE(sp1 == sp2) << "Spatial Poolers not equal";
 }
 
 TEST(SpatialPoolerTest, testClip) {


### PR DESCRIPTION
Aims to implement `equals` for two SpatialPooler instances for more convenient comparisons & tests. 

Fixes: #1383
Used for #1380 
Moved from https://github.com/numenta/nupic.core/pull/1384 
replaces #7 