### PR TITLE
SpatialPooler always applies boosting.

### DIFF
--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -509,11 +509,7 @@ void SpatialPooler::compute(SDR &input, bool learn, SDR &active) {
   calculateOverlap_(input, overlaps_);
   calculateOverlapPct_(overlaps_, overlapsPct_);
 
-  if (learn) {
-    boostOverlaps_(overlaps_, boostedOverlaps_);
-  } else {
-    boostedOverlaps_.assign(overlaps_.begin(), overlaps_.end());
-  }
+  boostOverlaps_(overlaps_, boostedOverlaps_);
 
   auto &activeVector = active.getFlatSparse();
   inhibitColumns_(boostedOverlaps_, activeVector);


### PR DESCRIPTION
The spatial pooler now applies boosting even when learning is off.  Reasons:
* The boost factors are learned from the input data, indirectly.
* The input patterns can have differing sparsities.  The mini-columns need to be
  able to adapt to the sparsity of the input pattern they respond to.  Boosting
  provides just this ability.
* This improves classification accuracy on the MNIST dataset by about 7%.