### PR TITLE
Connections raise permanence err

### DIFF
--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -457,31 +457,47 @@ void Connections::adaptSegment(const Segment segment, SDR &inputs,
   }
 }
 
-
+/** called for under-performing Segments. (can have synapses pruned, etc.)
+ * After the call, Segment will have at least 
+ * segmentThreshold synapses connected (>= permanenceThreshold).
+ * So the Segment could likely be active next time.
+ */
 void Connections::raisePermanencesToThreshold(
                   const Segment    segment,
                   const Permanence permanenceThreshold,
                   const UInt       segmentThreshold)
 {
-  if( segmentThreshold == 0 )
+  if( segmentThreshold == 0 ) //no synapses requested to be connected, done.
     return;
 
   auto &segData = segments_[segment];
-  if( segData.numConnected >= segmentThreshold )
+  if( segData.numConnected >= segmentThreshold ) //the segment already satisfies the requirement, done.
     return;
 
   vector<Synapse> &synapses = segData.synapses;
-  if( synapses.empty()) return; //otherwise crashes! can empty segments/synapses naturally occur? 
+  if( synapses.empty()) return; //no synapses to raise permanences to, no work
+  // Prune empty segment? No. 
+  // The SP calls this method, but the SP does not do any pruning. 
+  // The TM already has code to do pruning, but it doesn't ever call this method.
+
+  // There can be situation when synapses are pruned so the segment has too few synapses to ever activate. 
+  // (so we cannot satisfy the >= segmentThreshold connected). 
+  // In this case the method should do the next best thing and connect as many synapses as it can.
+  //
+  //keep segmentThreshold within synapses range
+  const auto threshold = std::min((size_t)segmentThreshold, synapses.size());
+
 
   // Sort the potential pool by permanence values, and look for the synapse with
   // the N'th greatest permanence, where N is the desired minimum number of
   // connected synapses.  Then calculate how much to increase the N'th synapses
   // permance by such that it becomes a connected synapse.
+  // After that there will be at least N synapses connected.
 
   auto minPermSynPtr = synapses.begin() + segmentThreshold - 1;
   // Do a partial sort, it's faster than a full sort. Only minPermSynPtr is in
   // its final sorted position.
-  auto permanencesGreater = [&](Synapse &A, Synapse &B)
+  const auto permanencesGreater = [&](const Synapse &A, const Synapse &B)
     { return synapses_[A].permanence > synapses_[B].permanence; };
   std::nth_element(synapses.begin(), minPermSynPtr, synapses.end(), permanencesGreater);
 
@@ -490,7 +506,7 @@ void Connections::raisePermanencesToThreshold(
     return;            // Enough synapses are already connected.
 
   // Raise the permance of all synapses in the potential pool uniformly.
-  for( const auto &syn : synapses )
+  for( const auto &syn : synapses ) //TODO vectorize: vector + const to all members
     updateSynapsePermanence(syn, synapses_[syn].permanence + increment);
 }
 

--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -494,7 +494,7 @@ void Connections::raisePermanencesToThreshold(
   // permance by such that it becomes a connected synapse.
   // After that there will be at least N synapses connected.
 
-  auto minPermSynPtr = synapses.begin() + segmentThreshold - 1;
+  auto minPermSynPtr = synapses.begin() + threshold - 1;
   // Do a partial sort, it's faster than a full sort. Only minPermSynPtr is in
   // its final sorted position.
   const auto permanencesGreater = [&](const Synapse &A, const Synapse &B)

--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -471,6 +471,7 @@ void Connections::raisePermanencesToThreshold(
     return;
 
   vector<Synapse> &synapses = segData.synapses;
+  if( synapses.empty()) return; //otherwise crashes! can empty segments/synapses naturally occur? 
 
   // Sort the potential pool by permanence values, and look for the synapse with
   // the N'th greatest permanence, where N is the desired minimum number of

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -463,12 +463,26 @@ TEST(ConnectionsTest, testRaisePermanencesToThreshold) {
                                                       synPermBelowStimulusInc);
     }
   }
+ }
 
+
+TEST(ConnectionsTest, testRaisePermanencesToThresholdOutOfBounds) {
+  Connections con(1001, 0.21f);
+ 	
   // check empty segment (with no synapse data) 
   auto emptySegment = con.createSegment(0);
   auto synapses = con.synapsesForSegment(emptySegment);
   NTA_CHECK(synapses.empty()) << "We want to create a Segment with none synapses";
   EXPECT_NO_THROW( con.raisePermanencesToThreshold(emptySegment, (Permanence)0.1337, 3u) ) << "raisePermanence fails when empty Segment encountered";
+
+  // check segment with 3 synapses, but wanted to raise 5
+  auto segWith3Syn = con.createSegment(0);
+  //add 3 synapses
+  con.createSynapse( segWith3Syn, 33, 0.001f);
+  con.createSynapse( segWith3Syn, 18, 0.25f);
+  con.createSynapse( segWith3Syn, 121, 0.00001f);
+  NTA_CHECK(con.synapsesForSegment(segWith3Syn).size() == 3) << "We failed to create 3 synapses on a segment";
+  EXPECT_NO_THROW( con.raisePermanencesToThreshold(segWith3Syn, (Permanence)0.666, 5u) ) << "raisePermanence fails when lower number of available synapses than requested by threshold";
 
 }
 

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -463,6 +463,13 @@ TEST(ConnectionsTest, testRaisePermanencesToThreshold) {
                                                       synPermBelowStimulusInc);
     }
   }
+
+  // check empty segment (with no synapse data) 
+  auto emptySegment = con.createSegment(0);
+  auto synapses = con.synapsesForSegment(emptySegment);
+  NTA_CHECK(synapses.empty()) << "We want to create a Segment with none synapses";
+  EXPECT_NO_THROW( con.raisePermanencesToThreshold(emptySegment, (Permanence)0.1337, 3u) ) << "raisePermanence fails when empty Segment encountered";
+
 }
 
 TEST(ConnectionsTest, testBumpSegment) {


### PR DESCRIPTION
- unit test that crashes Connections with segfault
- a fix proposed (better, if we can confirm that Segments with no synapses cannot occur?!) 

Fixes #246 