### PR TITLE
Fix #274 compiler error for delete-non-virtual-dtor.

### DIFF
--- a/src/nupic/utils/SdrMetrics.hpp
+++ b/src/nupic/utils/SdrMetrics.hpp
@@ -124,7 +124,7 @@ public:
         callback( data, 1.0f / std::min( period_, (UInt) ++samples_ ));
     }
 
-    ~SDR_MetricsHelper_() {
+    virtual ~SDR_MetricsHelper_() {
         deconstruct();
     }
 };


### PR DESCRIPTION
I've made a quick PR for this issue to fix the said build error. 

I'm new to this code and haven't really had time so far to consider its logic if my fix would break something. However compile-wise this will fix the compiler error caused by delete-non-virtual-dtor option. There are other ways to fix this.

Please review.
@ctrl-z-9000-times @breznak 

I confirm that I was able to install the nupic.cpp and nupic.py with this fix.

EDIT:
fixes #274 
Fixes #262 
