### PR TITLE
Rename SDR Proxy to Reshape

### DIFF
--- a/bindings/py/cpp_src/bindings/algorithms/py_SDR.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_SDR.cpp
@@ -301,8 +301,8 @@ Example Usage:
     A.coordinates =  ([1, 1, 2], [0, 1, 2])
     B.coordinates -> ([2, 2, 5], [0, 1, 0])
 
-SDR_Reshape supports pickle, however loading a pickled SDR proxy will return an
-SDR object, not an SDR_Reshape object.)");
+SDR_Reshape supports pickle, however loading a pickled SDR Reshape will return
+an SDR object, not an SDR_Reshape object.)");
 
         py_Reshape.def( py::init<SDR&, vector<UInt>>(),
 R"(Argument sdr is the data source to reshape.

--- a/bindings/py/cpp_src/bindings/algorithms/py_SDR.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_SDR.cpp
@@ -289,32 +289,26 @@ special, it is replaced with the system time.  The default seed is 0.)",
         }));
 
 
-        py::class_<SDR_Proxy, SDR> py_Proxy(m, "SDR_Proxy",
-R"(SDR_Proxy presents a view onto an SDR.
-    * Proxies always have the same value as their source SDR.
-    * Proxies can be used in place of an SDR.
-    * Proxies are read only.
-    * Proxies can have different dimensions than their source SDR.
+        py::class_<SDR_Reshape, SDR> py_Reshape(m, "SDR_Reshape",
+R"(SDR_Reshape presents a view onto an SDR with different dimensions.
+    * The resulting SDR always has the same value as its source SDR.
+    * The resulting SDR is read only.
 
 Example Usage:
     # Convert SDR dimensions from (4 x 4) to (8 x 2)
     A = SDR([ 4, 4 ])
-    B = SDR_Proxy( A, [8, 2])
+    B = SDR_Reshape( A, [8, 2])
     A.coordinates =  ([1, 1, 2], [0, 1, 2])
     B.coordinates -> ([2, 2, 5], [0, 1, 0])
 
-SDR_Proxy supports pickle, however loading a pickled SDR proxy will return an
-SDR, not an SDR_Proxy.)");
+SDR_Reshape supports pickle, however loading a pickled SDR proxy will return an
+SDR object, not an SDR_Reshape object.)");
 
-        py_Proxy.def( py::init<SDR&, vector<UInt>>(),
-R"(Argument sdr is the data source make a view of.
+        py_Reshape.def( py::init<SDR&, vector<UInt>>(),
+R"(Argument sdr is the data source to reshape.
 
-Argument dimensions A list of dimension sizes, defining the shape of the SDR.
-Optional, if not given then this Proxy will have the same dimensions as the
-given SDR.)",
+Argument dimensions A list of dimension sizes, defining the shape of the SDR.)",
             py::arg("sdr"), py::arg("dimensions"));
-
-        py_Proxy.def( py::init<SDR&>(), py::arg("sdr"));
 
 
         py::class_<SDR_Intersection, SDR> py_Intersect(m, "SDR_Intersection",

--- a/bindings/py/tests/SDR_Metrics_test.py
+++ b/bindings/py/tests/SDR_Metrics_test.py
@@ -25,7 +25,7 @@ import numpy as np
 import unittest
 import pytest
 
-from nupic.bindings.algorithms import SDR, SDR_Proxy
+from nupic.bindings.algorithms import SDR
 from nupic.bindings.algorithms import SDR_Sparsity, SDR_ActivationFrequency, SDR_Overlap, SDR_Metrics
 
 class SdrMetricsTest(unittest.TestCase):

--- a/bindings/py/tests/SDR_test.py
+++ b/bindings/py/tests/SDR_test.py
@@ -331,15 +331,15 @@ class SdrReshapeTest(unittest.TestCase):
 
     def testLostSDR(self):
         # You need to keep a reference to the SDR, since SDR class does not use smart pointers.
-        B = SDR_Reshape(SDR((1000,)))
+        B = SDR_Reshape(SDR((1000,)), [1000])
         with self.assertRaises(RuntimeError):
             B.dense
 
     def testChaining(self):
         A = SDR([10,10])
-        B = SDR_Reshape(A)
-        C = SDR_Reshape(B)
-        D = SDR_Reshape(B)
+        B = SDR_Reshape(A, [100])
+        C = SDR_Reshape(B, [4, 25])
+        D = SDR_Reshape(B, [1, 100])
 
         A.dense.fill( 1 )
         A.dense = A.dense

--- a/bindings/py/tests/SDR_test.py
+++ b/bindings/py/tests/SDR_test.py
@@ -26,7 +26,7 @@ import unittest
 import pytest
 import time
 
-from nupic.bindings.algorithms import SDR, SDR_Proxy, SDR_Intersection, SDR_Concatenation
+from nupic.bindings.algorithms import SDR, SDR_Reshape, SDR_Intersection, SDR_Concatenation
 
 class SdrTest(unittest.TestCase):
     def testExampleUsage(self):
@@ -320,26 +320,26 @@ class SdrTest(unittest.TestCase):
             assert( A == B )
 
 
-class SdrProxyTest(unittest.TestCase):
+class SdrReshapeTest(unittest.TestCase):
     def testExampleUsage(self):
-        assert( issubclass(SDR_Proxy, SDR) )
+        assert( issubclass(SDR_Reshape, SDR) )
         # Convert SDR dimensions from (4 x 4) to (8 x 2)
         A = SDR([ 4, 4 ])
-        B = SDR_Proxy( A, [8, 2])
+        B = SDR_Reshape( A, [8, 2])
         A.coordinates =  ([1, 1, 2], [0, 1, 2])
         assert( (np.array(B.coordinates) == ([2, 2, 5], [0, 1, 0]) ).all() )
 
     def testLostSDR(self):
         # You need to keep a reference to the SDR, since SDR class does not use smart pointers.
-        B = SDR_Proxy(SDR((1000,)))
+        B = SDR_Reshape(SDR((1000,)))
         with self.assertRaises(RuntimeError):
             B.dense
 
     def testChaining(self):
         A = SDR([10,10])
-        B = SDR_Proxy(A)
-        C = SDR_Proxy(B)
-        D = SDR_Proxy(B)
+        B = SDR_Reshape(A)
+        C = SDR_Reshape(B)
+        D = SDR_Reshape(B)
 
         A.dense.fill( 1 )
         A.dense = A.dense

--- a/src/nupic/types/Sdr.hpp
+++ b/src/nupic/types/Sdr.hpp
@@ -196,7 +196,7 @@ protected:
      * Destroy this SDR.  Makes SDR unusable, should error or clearly fail if
      * used.  Also sends notification to all watchers via destroyCallbacks.
      * This is a separate method from ~SDR so that SDRs can be destroyed long
-     * before they're deallocated; SDR Proxy does this.
+     * before they're deallocated.
      */
     virtual void deconstruct();
 

--- a/src/nupic/types/SdrProxy.hpp
+++ b/src/nupic/types/SdrProxy.hpp
@@ -131,8 +131,8 @@ public:
             return parent->getCoordinates();
         }
         else {
-            // Don't override getCoordinates().  It will call either getDense() or
-            // getSparse() to get its data, and will use this proxies
+            // Don't override getCoordinates().  It will call either getDense()
+            // or getSparse() to get its data, and will use this SDR Reshape's
             // dimensions.
             return SDR::getCoordinates();
         }

--- a/src/nupic/types/SdrProxy.hpp
+++ b/src/nupic/types/SdrProxy.hpp
@@ -55,52 +55,51 @@ private:
 };
 
 /**
- * SDR_Proxy class
+ * SDR_Reshape class
  *
  * ### Description
- * SDR_Proxy presents a view onto an SDR.
- *      + Proxies have the same value as their source SDR, at all times and
- *        automatically.
- *      + SDR_Proxy is a subclass of SDR and be safely typecast to an SDR.
- *      + Proxies can have different dimensions than their source SDR.
- *      + Proxies are read only.
+ * SDR_Reshape presents a view onto an SDR with different dimensions.
+ *      + SDR_Reshape is a subclass of SDR and be safely typecast to an SDR.
+ *      + The resulting SDR has the same value as the source SDR, at all times
+ *        and automatically.
+ *      + The resulting SDR is read only.
  *
- * SDR and SDR_Proxy classes tell each other when they are created and
- * destroyed.  Proxies can be created and destroyed as needed.  Proxies will
- * throw an exception if they are used after their source SDR has been
+ * SDR and SDR_Reshape classes tell each other when they are created and
+ * destroyed.  SDR_Reshape can be created and destroyed as needed.  SDR_Reshape
+ * will throw an exception if it is used after its source SDR has been
  * destroyed.
  *
  * Example Usage:
  *      // Convert SDR dimensions from (4 x 4) to (8 x 2)
- *      SDR       A(    { 4, 4 })
- *      SDR_Proxy B( A, { 8, 2 })
+ *      SDR         A(    { 4, 4 })
+ *      SDR_Reshape B( A, { 8, 2 })
  *      A.setCoordinates( {1, 1, 2}, {0, 1, 2}} )
  *      B.getCoordinates()  ->  {{2, 2, 5}, {0, 1, 0}}
  *
- * SDR_Proxy partially supports the Serializable interface.  SDR_Proxies can be
- * saved but can not be loaded.
+ * SDR_Reshape partially supports the Serializable interface.  SDR_Reshape can
+ * be saved but can not be loaded.
  */
-class SDR_Proxy : public SDR_ReadOnly_
+class SDR_Reshape : public SDR_ReadOnly_
 {
 public:
     /**
-     * Create an SDR_Proxy object.
+     * Reshape an SDR.
      *
      * @param sdr Source SDR to make a view of.
      *
      * @param dimensions A list of dimension sizes, defining the shape of the
-     * SDR.  Optional, if not given then this Proxy will have the same
+     * SDR.  Optional, if not given then this SDR will have the same
      * dimensions as the given SDR.
      */
-    SDR_Proxy(SDR &sdr)
-        : SDR_Proxy(sdr, sdr.dimensions)
+    SDR_Reshape(SDR &sdr)
+        : SDR_Reshape(sdr, sdr.dimensions)
         {}
 
-    SDR_Proxy(SDR &sdr, const vector<UInt> &dimensions)
+    SDR_Reshape(SDR &sdr, const vector<UInt> &dimensions)
         : SDR_ReadOnly_( dimensions ) {
         clear();
         parent = &sdr;
-        NTA_CHECK( size == parent->size ) << "SDR Proxy must have same size as given SDR.";
+        NTA_CHECK( size == parent->size ) << "SDR Reshape must have same size as given SDR.";
         callback_handle = parent->addCallback( [&] () {
             clear();
             do_callbacks();
@@ -110,7 +109,7 @@ public:
         });
     }
 
-    ~SDR_Proxy() override
+    ~SDR_Reshape() override
         { deconstruct(); }
 
     SDR_dense_t& getDense() const override {

--- a/src/nupic/types/SdrProxy.hpp
+++ b/src/nupic/types/SdrProxy.hpp
@@ -78,6 +78,8 @@ private:
  *
  * SDR_Reshape partially supports the Serializable interface.  SDR_Reshape can
  * be saved but can not be loaded.
+ *
+ * Note: SDR_Reshape used to be called SDR_Proxy. See PR #298
  */
 class SDR_Reshape : public SDR_ReadOnly_
 {

--- a/src/test/unit/types/SdrProxyTest.cpp
+++ b/src/test/unit/types/SdrProxyTest.cpp
@@ -23,38 +23,38 @@
 using namespace std;
 using namespace nupic;
 
-TEST(SdrProxyTest, TestProxyExamples) {
-    SDR       A(    { 4, 4 });
-    SDR_Proxy B( A, { 8, 2 });
+TEST(SdrReshapeTest, TestReshapeExamples) {
+    SDR         A(    { 4, 4 });
+    SDR_Reshape B( A, { 8, 2 });
     A.setCoordinates(SDR_coordinate_t({{1, 1, 2}, {0, 1, 2}}));
     auto coords = B.getCoordinates();
     ASSERT_EQ(coords, SDR_coordinate_t({{2, 2, 5}, {0, 1, 0}}));
 }
 
-TEST(SdrProxyTest, TestProxyConstructor) {
-    SDR         A({ 11 });
-    SDR_Proxy   B( A );
+TEST(SdrReshapeTest, TestReshapeConstructor) {
+    SDR           A({ 11 });
+    SDR_Reshape   B( A );
     ASSERT_EQ( A.dimensions, B.dimensions );
-    SDR_Proxy   C( A, { 11 });
-    SDR         D({ 5, 4, 3, 2, 1 });
-    SDR_Proxy   E( D, {1, 1, 1, 120, 1});
-    SDR_Proxy   F( D, { 20, 6 });
-    SDR_Proxy   X( (SDR&) F );
+    SDR_Reshape   C( A, { 11 });
+    SDR           D({ 5, 4, 3, 2, 1 });
+    SDR_Reshape   E( D, {1, 1, 1, 120, 1});
+    SDR_Reshape   F( D, { 20, 6 });
+    SDR_Reshape   X( (SDR&) F );
 
     // Test that proxies can be safely made and destroyed.
-    SDR_Proxy *G = new SDR_Proxy( A );
-    SDR_Proxy *H = new SDR_Proxy( A );
-    SDR_Proxy *I = new SDR_Proxy( A );
+    SDR_Reshape *G = new SDR_Reshape( A );
+    SDR_Reshape *H = new SDR_Reshape( A );
+    SDR_Reshape *I = new SDR_Reshape( A );
     A.zero();
     H->getDense();
     delete H;
     I->getDense();
     A.zero();
-    SDR_Proxy *J = new SDR_Proxy( A );
+    SDR_Reshape *J = new SDR_Reshape( A );
     J->getDense();
-    SDR_Proxy *K = new SDR_Proxy( A );
+    SDR_Reshape *K = new SDR_Reshape( A );
     delete K;
-    SDR_Proxy *L = new SDR_Proxy( A );
+    SDR_Reshape *L = new SDR_Reshape( A );
     L->getCoordinates();
     delete L;
     delete G;
@@ -64,23 +64,23 @@ TEST(SdrProxyTest, TestProxyConstructor) {
     A.getDense();
 
     // Test invalid dimensions
-    ASSERT_ANY_THROW( new SDR_Proxy( A, {2, 5}) );
-    ASSERT_ANY_THROW( new SDR_Proxy( A, {11, 0}) );
+    ASSERT_ANY_THROW( new SDR_Reshape( A, {2, 5}) );
+    ASSERT_ANY_THROW( new SDR_Reshape( A, {11, 0}) );
 }
 
-TEST(SdrProxyTest, TestProxyDeconstructor) {
+TEST(SdrReshapeTest, TestReshapeDeconstructor) {
     SDR       *A = new SDR({12});
-    SDR_Proxy *B = new SDR_Proxy( *A );
-    SDR_Proxy *C = new SDR_Proxy( *A, {3, 4} );
-    SDR_Proxy *D = new SDR_Proxy( *C, {4, 3} );
-    SDR_Proxy *E = new SDR_Proxy( *C, {2, 6} );
+    SDR_Reshape *B = new SDR_Reshape( *A );
+    SDR_Reshape *C = new SDR_Reshape( *A, {3, 4} );
+    SDR_Reshape *D = new SDR_Reshape( *C, {4, 3} );
+    SDR_Reshape *E = new SDR_Reshape( *C, {2, 6} );
     D->getDense();
     E->getCoordinates();
     // Test subtree deletion
     delete C;
     ASSERT_ANY_THROW( D->getDense() );
     ASSERT_ANY_THROW( E->getCoordinates() );
-    ASSERT_ANY_THROW( new SDR_Proxy( *E ) );
+    ASSERT_ANY_THROW( new SDR_Reshape( *E ) );
     delete D;
     // Test rest of tree is OK.
     B->getSparse();
@@ -95,9 +95,9 @@ TEST(SdrProxyTest, TestProxyDeconstructor) {
     delete E;
 }
 
-TEST(SdrProxyTest, TestProxyThrows) {
+TEST(SdrReshapeTest, TestReshapeThrows) {
     SDR A({10});
-    SDR_Proxy B(A, {2, 5});
+    SDR_Reshape B(A, {2, 5});
     SDR *C = &B;
 
     ASSERT_ANY_THROW( C->setDense( SDR_dense_t( 10, 1 ) ));
@@ -109,9 +109,9 @@ TEST(SdrProxyTest, TestProxyThrows) {
     ASSERT_ANY_THROW( C->addNoise(0.10f) );
 }
 
-TEST(SdrProxyTest, TestProxyGetters) {
+TEST(SdrReshapeTest, TestReshapeGetters) {
     SDR A({ 2, 3 });
-    SDR_Proxy B( A, { 3, 2 });
+    SDR_Reshape B( A, { 3, 2 });
     SDR *C = &B;
     // Test getting dense
     A.setDense( SDR_dense_t({ 0, 1, 0, 0, 1, 0 }) );
@@ -132,38 +132,38 @@ TEST(SdrProxyTest, TestProxyGetters) {
     // Test getting sparse, when the parent SDR already has sparse computed and
     // the dimensions are the same.
     A.zero();
-    SDR_Proxy D( A );
+    SDR_Reshape D( A );
     SDR *E = &D;
     A.setCoordinates( SDR_coordinate_t({ {0, 1}, {0, 1} }));
     ASSERT_EQ( E->getCoordinates(), SDR_coordinate_t({ {0, 1}, {0, 1} }) );
 }
 
-TEST(SdrProxyTest, TestSaveLoad) {
-    const char *filename = "SdrProxySerialization.tmp";
+TEST(SdrReshapeTest, TestSaveLoad) {
+    const char *filename = "SdrReshapeSerialization.tmp";
     ofstream outfile;
     outfile.open(filename);
 
     // Test zero value
     SDR zero({ 3, 3 });
-    SDR_Proxy z( zero );
+    SDR_Reshape z( zero );
     z.save( outfile );
 
     // Test dense data
     SDR dense({ 3, 3 });
-    SDR_Proxy d( dense );
+    SDR_Reshape d( dense );
     dense.setDense(SDR_dense_t({ 0, 1, 0, 0, 1, 0, 0, 0, 1 }));
     Serializable &ser = d;
     ser.save( outfile );
 
     // Test flat data
     SDR flat({ 3, 3 });
-    SDR_Proxy f( flat );
+    SDR_Reshape f( flat );
     flat.setSparse(SDR_sparse_t({ 1, 4, 8 }));
     f.save( outfile );
 
     // Test index data
     SDR index({ 3, 3 });
-    SDR_Proxy x( index );
+    SDR_Reshape x( index );
     index.setCoordinates(SDR_coordinate_t({
             { 0, 1, 2 },
             { 1, 1, 2 }}));

--- a/src/test/unit/types/SdrProxyTest.cpp
+++ b/src/test/unit/types/SdrProxyTest.cpp
@@ -41,7 +41,7 @@ TEST(SdrReshapeTest, TestReshapeConstructor) {
     SDR_Reshape   F( D, { 20, 6 });
     SDR_Reshape   X( (SDR&) F );
 
-    // Test that proxies can be safely made and destroyed.
+    // Test that SDR Reshapes can be safely made and destroyed.
     SDR_Reshape *G = new SDR_Reshape( A );
     SDR_Reshape *H = new SDR_Reshape( A );
     SDR_Reshape *I = new SDR_Reshape( A );
@@ -90,7 +90,7 @@ TEST(SdrReshapeTest, TestReshapeDeconstructor) {
     delete A;
     ASSERT_ANY_THROW( B->getDense() );
     ASSERT_ANY_THROW( E->getCoordinates() );
-    // Cleanup remaining Proxies.
+    // Cleanup remaining Reshapes.
     delete B;
     delete E;
 }

--- a/src/test/unit/types/SdrTest.cpp
+++ b/src/test/unit/types/SdrTest.cpp
@@ -695,8 +695,8 @@ TEST(SdrTest, TestCallbacks) {
     UInt handle1 = A.addCallback( call1 );
     UInt handle2 = A.addCallback( call2 );
     UInt handle3 = A.addCallback( call3 );
-    // Test proxies get callbacks
-    SDR_Proxy C(A);
+    // Test reshape proxies get callbacks
+    SDR_Reshape C(A);
     C.addCallback( call4 );
 
     // Remove call 2 and add it back in.

--- a/src/test/unit/types/SdrTest.cpp
+++ b/src/test/unit/types/SdrTest.cpp
@@ -695,7 +695,7 @@ TEST(SdrTest, TestCallbacks) {
     UInt handle1 = A.addCallback( call1 );
     UInt handle2 = A.addCallback( call2 );
     UInt handle3 = A.addCallback( call3 );
-    // Test reshape proxies get callbacks
+    // Test reshape gets callbacks
     SDR_Reshape C(A);
     C.addCallback( call4 );
 
@@ -745,7 +745,7 @@ TEST(SdrTest, TestCallbacks) {
     SDR B(A);
     ASSERT_ANY_THROW( B.removeCallback( handle1 ) );
     ASSERT_ANY_THROW( B.removeCallback( 0 ) );
-    // Check proxy got all of the callbacks.
+    // Check SDR Reshape got all of the callbacks and passed them along.
     ASSERT_EQ( count4, 4 );
 }
 

--- a/src/test/unit/utils/SdrMetricsTest.cpp
+++ b/src/test/unit/utils/SdrMetricsTest.cpp
@@ -18,7 +18,7 @@
 #include <gtest/gtest.h>
 #include <nupic/types/Sdr.hpp>
 #include <nupic/utils/SdrMetrics.hpp>
-/* Many of these tests also test SDR proxies. */
+/* Many of these tests also test SDR reshape. */
 #include <nupic/types/SdrProxy.hpp>
 #include <vector>
 #include <random>
@@ -64,7 +64,7 @@ TEST(SdrMetrics, TestSparsityExample) {
  */
 TEST(SdrMetrics, TestSparsityShortTerm) {
     SDR A({1});
-    SDR_Proxy B( A );
+    SDR_Reshape B( A );
     Real period = 10u;
     Real alpha  = 1.0f / period;
     SDR_Sparsity S( B, (UInt)period );
@@ -135,7 +135,7 @@ TEST(SdrMetrics, TestSparsityLongTerm) {
     auto iterations = 1000u;
 
     SDR A({1000u});
-    SDR_Proxy B( A );
+    SDR_Reshape B( A );
     SDR_Sparsity S( B, period );
 
     vector<Real> test_means{ 0.01f,  0.05f,  0.20f, 0.50f, 0.50f, 0.75f, 0.99f };
@@ -165,7 +165,7 @@ TEST(SdrMetrics, TestSparsityPrint) {
     // expected.
     cerr << endl << "YOU must manually verify this output!" << endl << endl;
     SDR A({ 2000u });
-    SDR_Proxy B( A );
+    SDR_Reshape B( A );
     SDR_Sparsity S( B, 10u );
 
     A.randomize( 0.30f );
@@ -185,7 +185,7 @@ TEST(SdrMetrics, TestSparsityPrint) {
 TEST(SdrMetrics, TestAF_Construct) {
     // Test creating it.
     SDR *A = new SDR({ 5 });
-    SDR_Proxy *B = new SDR_Proxy( *A );
+    SDR_Reshape *B = new SDR_Reshape( *A );
     SDR_ActivationFrequency F( *B, 100 );
     ASSERT_ANY_THROW( SDR_ActivationFrequency F( *A, 0u ) ); // Period > 0!
     // Test nothing crashes with no data.
@@ -220,7 +220,7 @@ TEST(SdrMetrics, TestAF_Construct) {
  */
 TEST(SdrMetrics, TestAF_Example) {
     SDR A({ 2u });
-    SDR_Proxy B( A );
+    SDR_Reshape B( A );
     SDR_ActivationFrequency F( B, 10u );
 
     A.setDense(SDR_dense_t{ 0, 0 });
@@ -247,7 +247,7 @@ TEST(SdrMetrics, TestAF_LongTerm) {
     const auto period  =  1000u;
     const auto runtime = 10000u;
     SDR A({ 20u });
-    SDR_Proxy B( A );
+    SDR_Reshape B( A );
     SDR_ActivationFrequency F( B, period );
 
 
@@ -274,7 +274,7 @@ TEST(SdrMetrics, TestAF_Entropy) {
     // Extact tests:
     // Test all zeros.
     SDR A({ size });
-    SDR_Proxy Px( A );
+    SDR_Reshape Px( A );
     SDR_ActivationFrequency F( Px, period );
     A.zero();
     EXPECT_FLOAT_EQ( F.entropy(), 0.0f );
@@ -377,7 +377,7 @@ TEST(SdrMetrics, TestOverlap_Construct) {
 
 TEST(SdrMetrics, TestOverlap_Example) {
     SDR A({ 10000u });
-    SDR_Proxy Px( A );
+    SDR_Reshape Px( A );
     SDR_Overlap B( Px, 1000u );
     A.randomize( 0.05f );
     A.addNoise( 0.95f );         //   5% overlap
@@ -392,7 +392,7 @@ TEST(SdrMetrics, TestOverlap_Example) {
 
 TEST(SdrMetrics, TestOverlap_ShortTerm) {
     SDR         A({ 1000u });
-    SDR_Proxy   Px( A );
+    SDR_Reshape   Px( A );
     SDR_Overlap V( Px, 10u );
 
     A.randomize( 0.20f ); // Initial value is taken after SDR_Overlap is created
@@ -426,7 +426,7 @@ TEST(SdrMetrics, TestOverlap_LongTerm) {
     const auto runtime = 1000u;
     const auto period  =  100u;
     SDR A({ 500u });
-    SDR_Proxy Px( A );
+    SDR_Reshape Px( A );
     SDR_Overlap V( Px, period );
     A.randomize( 0.45f );
 
@@ -461,7 +461,7 @@ TEST(SdrMetrics, TestOverlap_Print) {
     // expected.
     cerr << endl << "YOU must manually verify this output!" << endl << endl;
     SDR A({ 2000u });
-    SDR_Proxy Px( A );
+    SDR_Reshape Px( A );
     SDR_Overlap V( Px, 100u );
     A.randomize( 0.02f );
 
@@ -525,7 +525,7 @@ TEST(SdrMetrics, TestAllMetrics_Print) {
     // expected.
     cerr << endl << "YOU must manually verify this output!" << endl << endl;
     SDR A({ 4097u });
-    SDR_Proxy Px( A );
+    SDR_Reshape Px( A );
     SDR_Metrics M( Px, 100u );
 
     vector<Real> sparsity{ 0.02f, 0.15f, 0.06f, 0.50f, 0.0f };


### PR DESCRIPTION
See also issue #280 

This does not rename the files from SdrProxy.hpp to SdrReshape.hpp.  That will happen in another PR, because it makes it harder to view the `git diff`.  I'm also considering other file reorganizations related to the SDR tools.