### PR TITLE
New class BaseEncoder

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -8,7 +8,7 @@ The API is specified in the [API Docs](http://nupic.docs.numenta.org/prerelease/
 We try to remain compatible where possible, to make it easy for the users and programmers to switch/use 
 our implementation. And for developers to be easily able to navigate within the (known) codebase. 
 Despite of this, sometimes changes need to happen - be it for optimization, removal/replacement of some 
-features or implemenation detail, etc. 
+features or implementation detail, etc.
 
 
 ## API breaking changes in this repo
@@ -60,3 +60,5 @@ are ignored.  PR #271
 * Removed `void SpatialPooler::stripUnlearnedColumns()` as unused and not useful (did not effectively remove any columns). PR #286 
 
 * Changed SDRClassifier::compute() signature to take parameter `ClassifierResult& result`, instead of a raw pointer. PR #301
+
+* Rewrote ScalarEncoder API, all code using it needs to be rewritten. PR #314

--- a/bindings/py/cpp_src/CMakeLists.txt
+++ b/bindings/py/cpp_src/CMakeLists.txt
@@ -48,8 +48,13 @@ set(src_py_algorithms_files
     bindings/algorithms/py_HTM.cpp
     bindings/algorithms/py_SDRClassifier.cpp
     bindings/algorithms/py_SpatialPooler.cpp
-	)
-	
+    )
+
+set(src_py_encoders_files
+    bindings/encoders/encoders_module.cpp
+    bindings/encoders/py_ScalarEncoder.cpp
+    )
+
 set(src_py_engine_files
     plugin/PyBindRegion.cpp
     plugin/PyBindRegion.hpp
@@ -75,6 +80,7 @@ set(src_py_test_files
 	
 #set up file tabs in Visual Studio
 source_group("algorithms" FILES ${src_py_algorithms_files})
+source_group("encoders" FILES ${src_py_encoders_files})
 source_group("engine" FILES ${src_py_engine_files})
 source_group("math" FILES ${src_py_math_files})
 source_group("test" FILES ${src_py_test_files})
@@ -106,18 +112,35 @@ set(pybind11_INCLUDE_DIRS ${pybind11_SOURCE_DIR}/include)
 set(algorithms_shared_lib algorithms)
 pybind11_add_module(${algorithms_shared_lib} ${src_py_algorithms_files} )
 target_link_libraries(${algorithms_shared_lib} PRIVATE 
-		${core_library}
-		${COMMON_OS_LIBS}
-		)
+        ${core_library}
+        ${COMMON_OS_LIBS}
+        )
 target_compile_options(${algorithms_shared_lib} PUBLIC ${INTERNAL_CXX_FLAGS})
 target_compile_definitions(${algorithms_shared_lib} PRIVATE ${COMMON_COMPILER_DEFINITIONS})
 target_include_directories(${algorithms_shared_lib} PRIVATE 
-		${PYTHON_INCLUDE_DIRS}
-		${pybind11_INCLUDE_DIRS}
-		${CORE_LIB_INCLUDES} 
-		${EXTERNAL_INCLUDES}
-		${PROJECT_SOURCE_DIR}
-		)
+        ${PYTHON_INCLUDE_DIRS}
+        ${pybind11_INCLUDE_DIRS}
+        ${CORE_LIB_INCLUDES} 
+        ${EXTERNAL_INCLUDES}
+        ${PROJECT_SOURCE_DIR}
+        )
+
+
+set(encoders_shared_lib encoders)
+pybind11_add_module(${encoders_shared_lib} ${src_py_encoders_files} )
+target_link_libraries(${encoders_shared_lib} PRIVATE 
+        ${core_library}
+        ${COMMON_OS_LIBS}
+        )
+target_compile_options(${encoders_shared_lib} PUBLIC ${INTERNAL_CXX_FLAGS})
+target_compile_definitions(${encoders_shared_lib} PRIVATE ${COMMON_COMPILER_DEFINITIONS})
+target_include_directories(${encoders_shared_lib} PRIVATE 
+        ${PYTHON_INCLUDE_DIRS}
+        ${pybind11_INCLUDE_DIRS}
+        ${CORE_LIB_INCLUDES} 
+        ${EXTERNAL_INCLUDES}
+        ${PROJECT_SOURCE_DIR}
+        )
 
 
 set(engine_shared_lib engine_internal)
@@ -190,6 +213,7 @@ target_include_directories(${math_shared_lib} PRIVATE
 #
 ###################################################################
 install(TARGETS
+        encoders
         algorithms
         engine_internal
         math

--- a/bindings/py/cpp_src/bindings/encoders/encoders_module.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/encoders_module.cpp
@@ -1,0 +1,41 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2018, chhenning
+ *               2019, David McDougall
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * --------------------------------------------------------------------- */
+
+/** @file
+ * Encoders bindings Module file for pybind11
+ */
+
+#include <bindings/suppress_register.hpp>  //must be before pybind11.h
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace nupic_ext
+{
+    void init_ScalarEncoder(py::module&);
+}
+
+using namespace nupic_ext;
+
+PYBIND11_MODULE(encoders, m) {
+    m.doc() = "nupic.bindings.encoders"; // optional module docstring
+
+    init_ScalarEncoder(m);
+}

--- a/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
@@ -25,6 +25,7 @@
 namespace py = pybind11;
 
 #include <nupic/encoders/ScalarEncoder.hpp>
+#include <nupic/types/Sdr.hpp>
 
 namespace nupic_ext
 {
@@ -33,22 +34,84 @@ namespace nupic_ext
   void init_ScalarEncoder(py::module& m)
   {
     py::class_<ScalarEncoderParameters> py_ScalarEncParams(m, "ScalarEncoderParameters",
-        "TODO DOC");
-    py_ScalarEncParams.def_readwrite("minimum", &ScalarEncoderParameters::minimum, "TODO DOC");
-    py_ScalarEncParams.def_readwrite("maximum", &ScalarEncoderParameters::maximum, "TODO DOC");
-    py_ScalarEncParams.def_readwrite("clipInput", &ScalarEncoderParameters::clipInput, "TODO DOC");
-    py_ScalarEncParams.def_readwrite("periodic", &ScalarEncoderParameters::periodic, "TODO DOC");
-    py_ScalarEncParams.def_readwrite("activeBits", &ScalarEncoderParameters::activeBits, "TODO DOC");
-    py_ScalarEncParams.def_readwrite("sparsity", &ScalarEncoderParameters::sparsity, "TODO DOC");
-    py_ScalarEncParams.def_readwrite("size", &ScalarEncoderParameters::size, "TODO DOC");
-    py_ScalarEncParams.def_readwrite("radius", &ScalarEncoderParameters::radius, "TODO DOC");
-    py_ScalarEncParams.def_readwrite("resolution", &ScalarEncoderParameters::resolution, "TODO DOC");
-    py_ScalarEncParams.def(py::init<>(), "TODO DOC");
+        R"(
 
-    py::class_<ScalarEncoder> py_ScalarEnc(m, "ScalarEncoder", "TODO DOC");
-    py_ScalarEnc.def(py::init<ScalarEncoderParameters&>(), "TODO DOC");
+The following three (3) members define the total number of bits in the output:
+     size,
+     radius,
+     resolution.
+
+These are mutually exclusive and only one of them should be non-zero when
+constructing the encoder.)");
+
+    py_ScalarEncParams.def(py::init<>(), R"()");
+
+    py_ScalarEncParams.def_readwrite("minimum", &ScalarEncoderParameters::minimum,
+R"(This defines the range of the input signal. These endpoints are inclusive.)");
+
+    py_ScalarEncParams.def_readwrite("maximum", &ScalarEncoderParameters::maximum,
+R"(This defines the range of the input signal. These endpoints are inclusive.)");
+
+    py_ScalarEncParams.def_readwrite("clipInput", &ScalarEncoderParameters::clipInput,
+R"(This determines whether to allow input values outside the
+range [minimum, maximum].
+If true, the input will be clipped into the range [minimum, maximum].
+If false, inputs outside of the range will raise an error.)");
+
+    py_ScalarEncParams.def_readwrite("periodic", &ScalarEncoderParameters::periodic,
+R"(This controls what happens near the edges of the input range.
+
+If true, then the minimum & maximum input values are adjacent and the first and
+last bits of the output SDR are also adjacent.  The contiguous block of 1's
+wraps around the end back to the begining.
+
+If false, then minimum & maximum input values are the endpoints of the input
+range, are not adjacent, and activity does not wrap around.)");
+
+    py_ScalarEncParams.def_readwrite("activeBits", &ScalarEncoderParameters::activeBits,
+R"(This is the number of true bits in the encoded output SDR. The output
+encodings will have a contiguous block of this many 1's.)");
+
+    py_ScalarEncParams.def_readwrite("sparsity", &ScalarEncoderParameters::sparsity,
+R"(This is an alternative way to specify the the number of active bits.
+Sparsity requires that the size to also be specified.
+Specify only one of: activeBits or sparsity.)");
+
+    py_ScalarEncParams.def_readwrite("size", &ScalarEncoderParameters::size,
+R"(This is the total number of bits in the encoded output SDR.)");
+
+    py_ScalarEncParams.def_readwrite("radius", &ScalarEncoderParameters::radius,
+R"(Two inputs separated by more than the radius have non-overlapping
+representations. Two inputs separated by less than the radius will in general
+overlap in at least some of their bits. You can think of this as the radius of
+the input.)");
+
+    py_ScalarEncParams.def_readwrite("resolution", &ScalarEncoderParameters::resolution,
+R"(Two inputs separated by greater than, or equal to the resolution are guaranteed
+to have different representations.)");
+
+
+    py::class_<ScalarEncoder> py_ScalarEnc(m, "ScalarEncoder",
+R"(Encodes a real number as a contiguous block of 1's.
+
+The ScalarEncoder encodes a numeric (floating point) value into an array of
+bits. The output is 0's except for a contiguous block of 1's. The location of
+this contiguous block varies continuously with the input value.
+
+TODO, Example Usage & unit test for it.)");
+
+    py_ScalarEnc.def(py::init<ScalarEncoderParameters&>(), R"()");
     py_ScalarEnc.def_property_readonly("parameters",
-        [](const ScalarEncoder &self) { return self.parameters; });
-    py_ScalarEnc.def("encode", &ScalarEncoder::encode, "TODO DOC");
+        [](const ScalarEncoder &self) { return self.parameters; },
+R"(Contains the parameter structure which this encoder uses internally. All
+fields are filled in automatically.)");
+
+    py_ScalarEnc.def("encode", &ScalarEncoder::encode, R"()");
+
+    py_ScalarEnc.def("encode", [](ScalarEncoder &self, nupic::Real64 value) {
+        auto output = new nupic::SDR( self.dimensions );
+        self.encode( value, *output );
+        return output; },
+R"()");
   }
 }

--- a/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
@@ -38,7 +38,7 @@ namespace nupic_ext
     py_ScalarEncParams.def_readwrite("maximum", &ScalarEncoderParameters::maximum, "TODO DOC");
     py_ScalarEncParams.def_readwrite("clipInput", &ScalarEncoderParameters::clipInput, "TODO DOC");
     py_ScalarEncParams.def_readwrite("periodic", &ScalarEncoderParameters::periodic, "TODO DOC");
-    py_ScalarEncParams.def_readwrite("active", &ScalarEncoderParameters::active, "TODO DOC");
+    py_ScalarEncParams.def_readwrite("activeBits", &ScalarEncoderParameters::activeBits, "TODO DOC");
     py_ScalarEncParams.def_readwrite("sparsity", &ScalarEncoderParameters::sparsity, "TODO DOC");
     py_ScalarEncParams.def_readwrite("size", &ScalarEncoderParameters::size, "TODO DOC");
     py_ScalarEncParams.def_readwrite("radius", &ScalarEncoderParameters::radius, "TODO DOC");

--- a/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
@@ -30,8 +30,25 @@ using namespace nupic;
 
 namespace nupic_ext
 {
-    void init_ScalarEncoder(py::module& m)
-    {
-        py::class_<SDR> py_ScalarEncoder(m, "ScalarEncoder", "TODO DOC");
-    }
+  void init_ScalarEncoder(py::module& m)
+  {
+    py::class_<ScalarEncoderParameters> py_ScalarEncParams(m, "ScalarEncoderParameters",
+        "TODO DOC");
+    py_ScalarEncParams.def_readwrite("minimum", &ScalarEncoderParameters::minimum, "TODO DOC");
+    py_ScalarEncParams.def_readwrite("maximum", &ScalarEncoderParameters::maximum, "TODO DOC");
+    py_ScalarEncParams.def_readwrite("clipInput", &ScalarEncoderParameters::clipInput, "TODO DOC");
+    py_ScalarEncParams.def_readwrite("periodic", &ScalarEncoderParameters::periodic, "TODO DOC");
+    py_ScalarEncParams.def_readwrite("active", &ScalarEncoderParameters::active, "TODO DOC");
+    py_ScalarEncParams.def_readwrite("sparsity", &ScalarEncoderParameters::sparsity, "TODO DOC");
+    py_ScalarEncParams.def_readwrite("size", &ScalarEncoderParameters::size, "TODO DOC");
+    py_ScalarEncParams.def_readwrite("radius", &ScalarEncoderParameters::radius, "TODO DOC");
+    py_ScalarEncParams.def_readwrite("resolution", &ScalarEncoderParameters::resolution, "TODO DOC");
+    py_ScalarEncParams.def(py::init<>(), "TODO DOC");
+
+    py::class_<ScalarEncoder> py_ScalarEnc(m, "ScalarEncoder", "TODO DOC");
+    py_ScalarEnc.def(py::init<ScalarEncoderParameters&>(), "TODO DOC");
+    py_ScalarEnc.def_property_readonly("parameters",
+        [](const ScalarEncoder &self) { return self.parameters; });
+    py_ScalarEnc.def("encode", &ScalarEncoder::encode, "TODO DOC");
+  }
 }

--- a/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
@@ -26,10 +26,10 @@ namespace py = pybind11;
 
 #include <nupic/encoders/ScalarEncoder.hpp>
 
-using namespace nupic::encoders;
-
 namespace nupic_ext
 {
+  using namespace nupic::encoders;
+
   void init_ScalarEncoder(py::module& m)
   {
     py::class_<ScalarEncoderParameters> py_ScalarEncParams(m, "ScalarEncoderParameters",

--- a/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
@@ -26,7 +26,7 @@ namespace py = pybind11;
 
 #include <nupic/encoders/ScalarEncoder.hpp>
 
-using namespace nupic;
+using namespace nupic::encoders;
 
 namespace nupic_ext
 {

--- a/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
@@ -1,0 +1,37 @@
+/* ----------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2019, David McDougall
+ * The following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ * ---------------------------------------------------------------------- */
+
+#include <bindings/suppress_register.hpp>  //include before pybind11.h
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+namespace py = pybind11;
+
+#include <nupic/encoders/ScalarEncoder.hpp>
+
+using namespace nupic;
+
+namespace nupic_ext
+{
+    void init_ScalarEncoder(py::module& m)
+    {
+        py::class_<SDR> py_ScalarEncoder(m, "ScalarEncoder", "TODO DOC");
+    }
+}

--- a/bindings/py/packaging/setup.py
+++ b/bindings/py/packaging/setup.py
@@ -156,7 +156,7 @@ def getExtensionFileNames(platform):
     libExtension = "pyd"
   else:
     libExtension = "so"
-  libNames = ("algorithms", "engine_internal", "math")
+  libNames = ("algorithms", "encoders", "engine_internal", "math")
   libFiles = ["nupic.bindings.{}.{}".format(name, libExtension) for name in libNames]
   files = [os.path.join(DISTR_DIR, "src", "nupic", "bindings", name)
            for name in list(libFiles)]
@@ -248,7 +248,7 @@ if __name__ == "__main__":
     author="Numenta",
     author_email="help@numenta.org",
     url="https://github.com/htm-community/nupic.cpp",
-    long_description = "Numenta Platform for Intelligent Computing HTM-Community nupic core: nupic.bindings.[algorithms,engine_internal,math]",
+    long_description = "Numenta Platform for Intelligent Computing HTM-Community nupic core: nupic.bindings.[algorithms,encoders,engine_internal,math]",
     license = "GNU Affero General Public License v3 or later (AGPLv3+)",
     classifiers=[
       "Programming Language :: Python",

--- a/bindings/py/packaging/src/nupic/bindings/__init__.py
+++ b/bindings/py/packaging/src/nupic/bindings/__init__.py
@@ -71,6 +71,7 @@ def import_helper(name):
   return _mod;
   
 algorithms = import_helper('nupic.bindings.algorithms')
+encoders = import_helper('nupic.bindings.encoders')
 engine_internal = import_helper('nupic.bindings.engine_internal')
 math = import_helper('nupic.bindings.math')
 

--- a/bindings/py/tests/encoders/scalar_encoder_test.py
+++ b/bindings/py/tests/encoders/scalar_encoder_test.py
@@ -42,9 +42,9 @@ class ScalarEncoder_Test(unittest.TestCase):
         enc = ScalarEncoder( p )
         assert( not enc.parameters.clipInput )
         assert( not enc.parameters.periodic )
-        assert( abs(enc.parameters.sparsity   - 20/1000) < .01 )
-        assert( abs(enc.parameters.radius     - 7)       < 1)
-        assert( abs(enc.parameters.resolution - .35)     < .1)
+        assert( abs(enc.parameters.sparsity   - 20./1000) < .01 )
+        assert( abs(enc.parameters.radius     - 7)        < 1 )
+        assert( abs(enc.parameters.resolution - .35)      < .1 )
 
     def testEncode(self):
         p = ScalarEncoderParameters()
@@ -70,6 +70,15 @@ class ScalarEncoder_Test(unittest.TestCase):
 
         # Check a lot of bad parameters
         p.active = 12  # Can not activate more bits than are in the SDR.
+        with self.assertRaises(RuntimeError):
+            ScalarEncoder(p)
+
+        p.active = 0 # not enough active
+        with self.assertRaises(RuntimeError):
+            ScalarEncoder(p)
+
+        p.active = 1
+        p.size = 0 # not enough bits
         with self.assertRaises(RuntimeError):
             ScalarEncoder(p)
         p.active = 2

--- a/bindings/py/tests/encoders/scalar_encoder_test.py
+++ b/bindings/py/tests/encoders/scalar_encoder_test.py
@@ -35,10 +35,10 @@ class ScalarEncoder_Test(unittest.TestCase):
 
     def testConstructor(self):
         p = ScalarEncoderParameters()
-        p.size    = 1000
-        p.active  = 20
-        p.minimum = 0
-        p.maximum = 345
+        p.size       = 1000
+        p.activeBits = 20
+        p.minimum    = 0
+        p.maximum    = 345
         enc = ScalarEncoder( p )
         assert( not enc.parameters.clipInput )
         assert( not enc.parameters.periodic )
@@ -48,10 +48,10 @@ class ScalarEncoder_Test(unittest.TestCase):
 
     def testEncode(self):
         p = ScalarEncoderParameters()
-        p.size    = 10
-        p.active  = 3
-        p.minimum = 0
-        p.maximum = 1
+        p.size       = 10
+        p.activeBits = 3
+        p.minimum    = 0
+        p.maximum    = 1
         enc = ScalarEncoder(p)
         sdr = SDR( 10 )
         enc.encode( 0, sdr )
@@ -62,42 +62,42 @@ class ScalarEncoder_Test(unittest.TestCase):
     def testBadParameters(self):
         # Start with sane parameters.
         p = ScalarEncoderParameters()
-        p.size    = 10
-        p.active  = 2
-        p.minimum = 0
-        p.maximum = 1
+        p.size       = 10
+        p.activeBits = 2
+        p.minimum    = 0
+        p.maximum    = 1
         ScalarEncoder(p)
 
         # Check a lot of bad parameters
-        p.active = 12  # Can not activate more bits than are in the SDR.
+        p.activeBits = 12  # Can not activate more bits than are in the SDR.
         with self.assertRaises(RuntimeError):
             ScalarEncoder(p)
 
-        p.active = 0 # not enough active
+        p.activeBits = 0 # not enough active bits
         with self.assertRaises(RuntimeError):
             ScalarEncoder(p)
 
-        p.active = 1
+        p.activeBits = 1
         p.size = 0 # not enough bits
         with self.assertRaises(RuntimeError):
             ScalarEncoder(p)
-        p.active = 2
+        p.activeBits = 2
 
         p.maximum = -1 # Maximum is less than the minimum
         with self.assertRaises(RuntimeError):
             ScalarEncoder(p)
         p.maximum = 1
 
-        p.size     = 0
-        p.active   = 0
-        p.sparsity = .1  # Specify sparsity without output size
+        p.size       = 0
+        p.activeBits = 0
+        p.sparsity   = .1  # Specify sparsity without output size
         with self.assertRaises(RuntimeError):
             ScalarEncoder(p)
-        p.size     = 10
-        p.active   = 2
-        p.sparsity = 0
+        p.size       = 10
+        p.activeBits = 2
+        p.sparsity   = 0
 
-        p.sparsity = .2  # Sparsity & num active specified
+        p.sparsity = .2  # Sparsity & num activeBits specified
         with self.assertRaises(RuntimeError):
             ScalarEncoder(p)
         p.sparsity = 0
@@ -122,10 +122,10 @@ class ScalarEncoder_Test(unittest.TestCase):
     def testBadEncode(self):
         # Test bad SDR
         p = ScalarEncoderParameters()
-        p.size    = 10
-        p.active  = 2
-        p.minimum = 0
-        p.maximum = 1
+        p.size       = 10
+        p.activeBits = 2
+        p.minimum    = 0
+        p.maximum    = 1
         enc  = ScalarEncoder(p)
         good = SDR( 10 )
         bad  = SDR( 5 )
@@ -158,10 +158,10 @@ class ScalarEncoder_Test(unittest.TestCase):
 
     def testRadius(self):
         p = ScalarEncoderParameters()
-        p.active  =  10
-        p.minimum =   0
-        p.maximum = 100
-        p.radius  =  10
+        p.activeBits =  10
+        p.minimum    =   0
+        p.maximum    = 100
+        p.radius     =  10
         enc = ScalarEncoder(p)
         sdr1 = SDR( enc.parameters.size )
         sdr2 = SDR( enc.parameters.size )
@@ -184,7 +184,7 @@ class ScalarEncoder_Test(unittest.TestCase):
 
     def testResolution(self):
         p = ScalarEncoderParameters()
-        p.active     =  10
+        p.activeBits =  10
         p.minimum    =   0
         p.maximum    = 100
         p.resolution =  .5
@@ -214,10 +214,10 @@ class ScalarEncoder_Test(unittest.TestCase):
 
     def testNaNs(self):
         p = ScalarEncoderParameters()
-        p.size    = 100
-        p.active  =  10
-        p.minimum =   0
-        p.maximum = 100
+        p.size       = 100
+        p.activeBits =  10
+        p.minimum    =   0
+        p.maximum    = 100
         enc = ScalarEncoder(p)
         sdr = SDR( 100 )
         enc.encode( float("nan"), sdr )
@@ -225,11 +225,11 @@ class ScalarEncoder_Test(unittest.TestCase):
 
     def testPeriodic(self):
         p = ScalarEncoderParameters()
-        p.size     = 100
-        p.active   = 10
-        p.minimum  = 0
-        p.maximum  = 20
-        p.periodic = True
+        p.size       = 100
+        p.activeBits = 10
+        p.minimum    = 0
+        p.maximum    = 20
+        p.periodic   = True
         enc = ScalarEncoder( p )
         out = SDR( enc.parameters.size )
         mtr = SDR_Metrics(out, 9999)
@@ -248,11 +248,11 @@ class ScalarEncoder_Test(unittest.TestCase):
 
     def testStatistics(self):
         p = ScalarEncoderParameters()
-        p.size      = 100
-        p.active    = 10
-        p.minimum   = 0
-        p.maximum   = 20
-        p.clipInput = True
+        p.size       = 100
+        p.activeBits = 10
+        p.minimum    = 0
+        p.maximum    = 20
+        p.clipInput  = True
         enc = ScalarEncoder( p )
         del p
         out = SDR( enc.parameters.size )

--- a/bindings/py/tests/encoders/scalar_encoder_test.py
+++ b/bindings/py/tests/encoders/scalar_encoder_test.py
@@ -235,7 +235,7 @@ class ScalarEncoder_Test(unittest.TestCase):
         mtr = SDR_Metrics(out, 9999)
 
         for i in range(201 * 10 + 1):
-            x = (i % 201) / 10
+            x = (i % 201) / 10.
             enc.encode( x, out )
             # print( x, out.sparse )
 

--- a/bindings/py/tests/encoders/scalar_encoder_test.py
+++ b/bindings/py/tests/encoders/scalar_encoder_test.py
@@ -1,0 +1,274 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2019, David McDougall
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""Unit tests for Scalar Encoder."""
+
+import pickle
+import numpy as np
+import unittest
+import pytest
+import time
+
+from nupic.bindings.encoders import ScalarEncoder, ScalarEncoderParameters
+from nupic.bindings.algorithms import SDR, SDR_Metrics
+
+class ScalarEncoder_Test(unittest.TestCase):
+    @pytest.mark.skip("TODO UNIMPLEMENTED!")
+    def testExampleUsage(self):
+        1/0
+
+    def testConstructor(self):
+        p = ScalarEncoderParameters()
+        p.size    = 1000
+        p.active  = 20
+        p.minimum = 0
+        p.maximum = 345
+        enc = ScalarEncoder( p )
+        assert( not enc.parameters.clipInput )
+        assert( not enc.parameters.periodic )
+        assert( abs(enc.parameters.sparsity   - 20/1000) < .01 )
+        assert( abs(enc.parameters.radius     - 7)       < 1)
+        assert( abs(enc.parameters.resolution - .35)     < .1)
+
+    def testEncode(self):
+        p = ScalarEncoderParameters()
+        p.size    = 10
+        p.active  = 3
+        p.minimum = 0
+        p.maximum = 1
+        enc = ScalarEncoder(p)
+        sdr = SDR( 10 )
+        enc.encode( 0, sdr )
+        assert( list(sdr.sparse) == [0, 1, 2] )
+        enc.encode( 1, sdr )
+        assert( list(sdr.sparse) == [7, 8, 9] )
+
+    def testBadParameters(self):
+        # Start with sane parameters.
+        p = ScalarEncoderParameters()
+        p.size    = 10
+        p.active  = 2
+        p.minimum = 0
+        p.maximum = 1
+        ScalarEncoder(p)
+
+        # Check a lot of bad parameters
+        p.active = 12  # Can not activate more bits than are in the SDR.
+        with self.assertRaises(RuntimeError):
+            ScalarEncoder(p)
+        p.active = 2
+
+        p.maximum = -1 # Maximum is less than the minimum
+        with self.assertRaises(RuntimeError):
+            ScalarEncoder(p)
+        p.maximum = 1
+
+        p.size     = 0
+        p.active   = 0
+        p.sparsity = .1  # Specify sparsity without output size
+        with self.assertRaises(RuntimeError):
+            ScalarEncoder(p)
+        p.size     = 10
+        p.active   = 2
+        p.sparsity = 0
+
+        p.sparsity = .2  # Sparsity & num active specified
+        with self.assertRaises(RuntimeError):
+            ScalarEncoder(p)
+        p.sparsity = 0
+
+        p.clipInput = True # Incompatible features...
+        p.periodic  = True
+        with self.assertRaises(RuntimeError):
+            ScalarEncoder(p)
+        p.clipInput = False
+        p.periodic  = False
+
+        p.radius = 1 # Size specified too many times
+        with self.assertRaises(RuntimeError):
+            ScalarEncoder(p)
+        p.radius = 0
+
+        p.resolution = 1 # Size specified too many times
+        with self.assertRaises(RuntimeError):
+            ScalarEncoder(p)
+        p.resolution = 0
+
+    def testBadEncode(self):
+        # Test bad SDR
+        p = ScalarEncoderParameters()
+        p.size    = 10
+        p.active  = 2
+        p.minimum = 0
+        p.maximum = 1
+        enc  = ScalarEncoder(p)
+        good = SDR( 10 )
+        bad  = SDR( 5 )
+        enc.encode( .25, good )
+        with self.assertRaises(RuntimeError):
+            enc.encode( .25, bad )
+
+        # Test bad inputs, out of valid range & clipping disabled.
+        with self.assertRaises(RuntimeError):
+            enc.encode( -.0001, good )
+        with self.assertRaises(RuntimeError):
+            enc.encode( 1.0001, good )
+
+    def testClipInput(self):
+        p = ScalarEncoderParameters()
+        p.size      = 345
+        p.sparsity  = .05
+        p.minimum   = 0
+        p.maximum   = 1
+        p.clipInput = 1
+        enc  = ScalarEncoder(p)
+        sdr1 = SDR( 345 )
+        sdr2 = SDR( 345 )
+        enc.encode( 0,  sdr1 )
+        enc.encode( -1, sdr2 )
+        assert( sdr1 == sdr2 )
+        enc.encode( 1,  sdr1 )
+        enc.encode( 10, sdr2 )
+        assert( sdr1 == sdr2 )
+
+    def testRadius(self):
+        p = ScalarEncoderParameters()
+        p.active  =  10
+        p.minimum =   0
+        p.maximum = 100
+        p.radius  =  10
+        enc = ScalarEncoder(p)
+        sdr1 = SDR( enc.parameters.size )
+        sdr2 = SDR( enc.parameters.size )
+
+        enc.encode( 77, sdr1 )
+        enc.encode( 77, sdr2 )
+        assert( sdr1.getOverlap( sdr2 ) == 10 )
+
+        enc.encode( 0, sdr1 )
+        enc.encode( 1, sdr2 )
+        assert( sdr1.getOverlap( sdr2 ) == 9 )
+
+        enc.encode( 60, sdr1 )
+        enc.encode( 69, sdr2 )
+        assert( sdr1.getOverlap( sdr2 ) == 1 )
+
+        enc.encode( 45, sdr1 )
+        enc.encode( 55, sdr2 )
+        assert( sdr1.getOverlap( sdr2 ) == 0 )
+
+    def testResolution(self):
+        p = ScalarEncoderParameters()
+        p.active     =  10
+        p.minimum    =   0
+        p.maximum    = 100
+        p.resolution =  .5
+        enc = ScalarEncoder(p)
+        sdr1 = SDR( enc.parameters.size )
+        sdr2 = SDR( enc.parameters.size )
+
+        enc.encode( .0, sdr1 )
+        enc.encode( .1, sdr2 )
+        assert( sdr1 == sdr2 )
+
+        enc.encode( .0, sdr1 )
+        enc.encode( .6, sdr2 )
+        assert( sdr1.getOverlap( sdr2 ) == 9 )
+
+        enc.encode( 70,   sdr1 )
+        enc.encode( 72.5, sdr2 )
+        assert( sdr1.getOverlap( sdr2 ) == 5 )
+
+        enc.encode( 70, sdr1 )
+        enc.encode( 75, sdr2 )
+        assert( sdr1.getOverlap( sdr2 ) == 0 )
+
+        enc.encode( 60, sdr1 )
+        enc.encode( 80, sdr2 )
+        assert( sdr1.getOverlap( sdr2 ) == 0 )
+
+    def testNaNs(self):
+        p = ScalarEncoderParameters()
+        p.size    = 100
+        p.active  =  10
+        p.minimum =   0
+        p.maximum = 100
+        enc = ScalarEncoder(p)
+        sdr = SDR( 100 )
+        enc.encode( float("nan"), sdr )
+        assert( sdr.getSum() == 0 )
+
+    def testPeriodic(self):
+        p = ScalarEncoderParameters()
+        p.size     = 100
+        p.active   = 10
+        p.minimum  = 0
+        p.maximum  = 20
+        p.periodic = True
+        enc = ScalarEncoder( p )
+        out = SDR( enc.parameters.size )
+        mtr = SDR_Metrics(out, 9999)
+
+        for i in range(201 * 10 + 1):
+            x = (i % 201) / 10
+            enc.encode( x, out )
+            # print( x, out.sparse )
+
+        print(str(mtr))
+        assert( mtr.sparsity.min() >  .95 * .10 )
+        assert( mtr.sparsity.max() < 1.05 * .10 )
+        assert( mtr.activationFrequency.min() >  .9 * .10 )
+        assert( mtr.activationFrequency.max() < 1.1 * .10 )
+        assert( mtr.overlap.min() > .85 )
+
+    def testStatistics(self):
+        p = ScalarEncoderParameters()
+        p.size      = 100
+        p.active    = 10
+        p.minimum   = 0
+        p.maximum   = 20
+        p.clipInput = True
+        enc = ScalarEncoder( p )
+        del p
+        out = SDR( enc.parameters.size )
+        mtr = SDR_Metrics(out, 9999)
+
+        # The activation frequency of bits near the endpoints of the range is a
+        # little weird, because the bits at the very end are not used as often
+        # as the ones in the middle of the range, unless clipInputs is enabled.
+        # If clipInputs is enabled then the bits 1 radius from the end get used
+        # twice as often as the should because they respond to inputs off
+        # outside of the valid range as well as inputs inside of the range.
+        for i in np.linspace(
+                        enc.parameters.minimum - enc.parameters.radius / 2,
+                        enc.parameters.maximum + enc.parameters.radius / 2,
+                        100 + 10 ):
+            enc.encode( i, out )
+            # print( i, out.sparse )
+
+        print(str(mtr))
+        assert( mtr.sparsity.min() >  .95 * .10 )
+        assert( mtr.sparsity.max() < 1.05 * .10 )
+        assert( mtr.activationFrequency.min() >  .50 * .10 )
+        assert( mtr.activationFrequency.max() < 1.75 * .10 )
+        assert( mtr.overlap.min() > .85 )
+
+    @pytest.mark.skip(reason="Known issue: https://github.com/htm-community/nupic.cpp/issues/160")
+    def testPickle(self):
+        assert(False) # TODO: Unimplemented

--- a/bindings/py/tests/encoders/scalar_encoder_test.py
+++ b/bindings/py/tests/encoders/scalar_encoder_test.py
@@ -56,8 +56,8 @@ class ScalarEncoder_Test(unittest.TestCase):
         sdr = SDR( 10 )
         enc.encode( 0, sdr )
         assert( list(sdr.sparse) == [0, 1, 2] )
-        enc.encode( 1, sdr )
-        assert( list(sdr.sparse) == [7, 8, 9] )
+        sdr2 = enc.encode( 1 )
+        assert( list(sdr2.sparse) == [7, 8, 9] )
 
     def testBadParameters(self):
         # Start with sane parameters.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,7 @@ set(algorithm_files
 
 
 set(encoders_files 
+    nupic/encoders/BaseEncoder.hpp
     nupic/encoders/ScalarEncoder.cpp
     nupic/encoders/ScalarEncoder.hpp
 )

--- a/src/examples/hotgym/HelloSPTP.cpp
+++ b/src/examples/hotgym/HelloSPTP.cpp
@@ -47,7 +47,8 @@ using namespace std;
 using namespace nupic;
 using namespace nupic::utils;
 
-using nupic::ScalarEncoder;
+using nupic::encoders::ScalarEncoder;
+using nupic::encoders::ScalarEncoderParameters;
 
 using nupic::algorithms::spatial_pooler::SpatialPooler;
 

--- a/src/examples/hotgym/HelloSPTP.cpp
+++ b/src/examples/hotgym/HelloSPTP.cpp
@@ -26,6 +26,8 @@
 
 #include "HelloSPTP.hpp"
 
+#include "nupic/types/Sdr.hpp"
+
 #include "nupic/algorithms/Anomaly.hpp"
 
 #include "nupic/algorithms/Cells4.hpp"
@@ -74,7 +76,12 @@ Real64 BenchmarkHotgym::run(UInt EPOCHS, bool useSPlocal, bool useSPglobal, bool
 
   // initialize SP, TP, Anomaly, AnomalyLikelihood
   tInit.start();
-  ScalarEncoder enc(133, -100.0, 100.0, DIM_INPUT, 0.0, 0.0, false);
+  ScalarEncoderParameters encParams;
+  encParams.active = 133;
+  encParams.minimum = -100.0;
+  encParams.maximum = 100.0;
+  encParams.size = DIM_INPUT;
+  ScalarEncoder enc( encParams );
   NTA_INFO << "SP (l) local inhibition is slow, so we reduce its data 10x smaller"; //to make it reasonably fast for test, for comparison x10
   SpatialPooler spGlobal(vector<UInt>{DIM_INPUT}, vector<UInt>{COLS}); // Spatial pooler with globalInh
   SpatialPooler spLocal(vector<UInt>{DIM_INPUT}, vector<UInt>{COLS/10u}); // Spatial pooler with local inh
@@ -92,6 +99,7 @@ Real64 BenchmarkHotgym::run(UInt EPOCHS, bool useSPlocal, bool useSPglobal, bool
 
   // data for processing input
   vector<UInt> input(DIM_INPUT);
+  SDR inputSDR({DIM_INPUT});
   vector<UInt> outSP(COLS); // active array, output of SP/TP
   vector<UInt> outSPsparse;
   vector<UInt> outTP(tp.nCells());
@@ -115,8 +123,11 @@ Real64 BenchmarkHotgym::run(UInt EPOCHS, bool useSPlocal, bool useSPglobal, bool
 
     //Encode
     tEnc.start();
-    enc.encodeIntoArray(r, input.data());
+    enc.encode(r, inputSDR);
     tEnc.stop();
+    for(auto i = 0u; i < inputSDR.size; ++i) {
+      input[i] = (UInt) inputSDR.getDense()[i];
+    }
 
     //SP (global x local) 
     if(useSPlocal) {

--- a/src/examples/hotgym/HelloSPTP.cpp
+++ b/src/examples/hotgym/HelloSPTP.cpp
@@ -78,7 +78,7 @@ Real64 BenchmarkHotgym::run(UInt EPOCHS, bool useSPlocal, bool useSPglobal, bool
   // initialize SP, TP, Anomaly, AnomalyLikelihood
   tInit.start();
   ScalarEncoderParameters encParams;
-  encParams.active = 133;
+  encParams.activeBits = 133;
   encParams.minimum = -100.0;
   encParams.maximum = 100.0;
   encParams.size = DIM_INPUT;

--- a/src/nupic/encoders/BaseEncoder.hpp
+++ b/src/nupic/encoders/BaseEncoder.hpp
@@ -26,6 +26,7 @@
 #include <nupic/types/Sdr.hpp>
 
 namespace nupic {
+namespace encoders {
 
 /**
  * Description:
@@ -66,5 +67,6 @@ private:
     vector<UInt> dimensions_;
     UInt         size_;
 };
+} // end namespace encoders
 } // end namespace nupic
 #endif // NTA_ENCODERS_BASE

--- a/src/nupic/encoders/BaseEncoder.hpp
+++ b/src/nupic/encoders/BaseEncoder.hpp
@@ -1,0 +1,64 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2019, David McDougall
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ * ---------------------------------------------------------------------
+ */
+
+/** @file
+ * Defines the base class for all encoders.
+ */
+
+#ifndef NTA_ENCODERS_BASE
+#define NTA_ENCODERS_BASE
+
+#include <nupic/types/Sdr.hpp>
+
+namespace nupic {
+
+/**
+ * Description:
+ * Base class for all encoders.
+ */
+template<typename DataType>
+class BaseEncoder
+{
+private:
+    vector<UInt> dimensions_;
+    UInt         size_;
+
+protected:
+    BaseEncoder() {}
+
+    BaseEncoder(const vector<UInt> dimensions)
+        { initialize( dimensions ); }
+
+    virtual void initialize(const vector<UInt> dimensions) {
+        dimensions_ = dimensions;
+        size_       = SDR(dimensions).size;
+    }
+
+public:
+    virtual ~BaseEncoder() {}
+
+    const vector<UInt> &dimensions = dimensions_;
+    const UInt         &size       = size_;
+
+    virtual void reset() {}
+
+    virtual void encode(DataType input, SDR &output) = 0;
+};
+
+} // end namespace nupic
+#endif // NTA_ENCODERS_BASE

--- a/src/nupic/encoders/BaseEncoder.hpp
+++ b/src/nupic/encoders/BaseEncoder.hpp
@@ -58,7 +58,7 @@ protected:
     BaseEncoder(const vector<UInt> dimensions)
         { initialize( dimensions ); }
 
-    virtual void initialize(const vector<UInt> dimensions) {
+    void initialize(const vector<UInt> dimensions) {
         dimensions_ = dimensions;
         size_       = SDR(dimensions).size;
     }

--- a/src/nupic/encoders/BaseEncoder.hpp
+++ b/src/nupic/encoders/BaseEncoder.hpp
@@ -30,13 +30,26 @@ namespace nupic {
 /**
  * Description:
  * Base class for all encoders.
+ *
+ * Subclasses must implement method encode, and Serializable interface.
+ * Subclasses can optionally implement method reset.
  */
 template<typename DataType>
-class BaseEncoder
+class BaseEncoder : public Serializable
 {
-private:
-    vector<UInt> dimensions_;
-    UInt         size_;
+public:
+    /**
+     * Members dimensions & size describe the shape of the encoded output SDR.
+     * This is the total number of bits which the result has.
+     */
+    const vector<UInt> &dimensions = dimensions_;
+    const UInt         &size       = size_;
+
+    virtual void reset() {}
+
+    virtual void encode(DataType input, SDR &output) = 0;
+
+    virtual ~BaseEncoder() {}
 
 protected:
     BaseEncoder() {}
@@ -49,16 +62,9 @@ protected:
         size_       = SDR(dimensions).size;
     }
 
-public:
-    virtual ~BaseEncoder() {}
-
-    const vector<UInt> &dimensions = dimensions_;
-    const UInt         &size       = size_;
-
-    virtual void reset() {}
-
-    virtual void encode(DataType input, SDR &output) = 0;
+private:
+    vector<UInt> dimensions_;
+    UInt         size_;
 };
-
 } // end namespace nupic
 #endif // NTA_ENCODERS_BASE

--- a/src/nupic/encoders/ScalarEncoder.cpp
+++ b/src/nupic/encoders/ScalarEncoder.cpp
@@ -26,7 +26,8 @@
  * Implementation of the ScalarEncoder
  */
 
-#include <algorithm> // std::iota, std::min
+#include <algorithm> // std::min
+#include <numeric>   // std::iota
 #include <math.h>    // isnan
 #include <nupic/encoders/ScalarEncoder.hpp>
 

--- a/src/nupic/encoders/ScalarEncoder.cpp
+++ b/src/nupic/encoders/ScalarEncoder.cpp
@@ -43,17 +43,17 @@ void ScalarEncoder::initialize(ScalarEncoderParameters &parameters)
   NTA_CHECK( parameters.minimum < parameters.maximum );
 
   UInt num_active_args = 0;
-  if( parameters.active     > 0)    num_active_args++;
-  if( parameters.sparsity   > 0.0f) num_active_args++;
+  if( parameters.active     > 0)    { num_active_args++; }
+  if( parameters.sparsity   > 0.0f) { num_active_args++; }
   NTA_CHECK( num_active_args != 0u )
       << "Missing argument, need one of: 'active' or 'sparsity'.";
   NTA_CHECK( num_active_args == 1u )
       << "Too many arguments, choose only one of: 'active' or 'sparsity'.";
 
   UInt num_size_args = 0;
-  if( parameters.size       > 0u)   num_size_args++;
-  if( parameters.radius     > 0.0f) num_size_args++;
-  if( parameters.resolution > 0.0f) num_size_args++;
+  if( parameters.size       > 0u)   { num_size_args++; }
+  if( parameters.radius     > 0.0f) { num_size_args++; }
+  if( parameters.resolution > 0.0f) { num_size_args++; }
   NTA_CHECK( num_size_args != 0u )
       << "Missing argument, need one of: 'size', 'radius', 'resolution'.";
   NTA_CHECK( num_size_args == 1u )

--- a/src/nupic/encoders/ScalarEncoder.cpp
+++ b/src/nupic/encoders/ScalarEncoder.cpp
@@ -88,6 +88,7 @@ void ScalarEncoder::initialize(ScalarEncoderParameters &parameters)
   }
 
   if( args_.radius == 0.0f ) {
+    // TODO: Should this be the inputExtent instead of the outputExtent???
     args_.radius = args_.size * args_.resolution;
   }
 
@@ -132,6 +133,40 @@ void ScalarEncoder::encode(double input, SDR &output)
   }
 
   output.setDense( dense );
+}
+
+void ScalarEncoder::save(std::ostream &stream) const
+{
+  stream << "ScalarEncoder ";
+  stream << args_.minimum   << " ";
+  stream << args_.maximum   << " ";
+  stream << args_.clipInput << " ";
+  stream << args_.periodic  << " ";
+  stream << args_.active    << " ";
+  stream << args_.size      << " ";
+  stream << "~ScalarEncoder~" << endl;
+}
+
+void ScalarEncoder::load(std::istream &stream)
+{
+  string prelude;
+  stream >> prelude;
+  NTA_CHECK( prelude == "ScalarEncoder" );
+
+  ScalarEncoderParameters p;
+  stream >> p.minimum;
+  stream >> p.maximum;
+  stream >> p.clipInput;
+  stream >> p.periodic;
+  stream >> p.active;
+  stream >> p.size;
+
+  string postlude;
+  stream >> postlude;
+  NTA_CHECK( postlude == "~ScalarEncoder~" );
+  stream.ignore( 1 ); // Eat the trailing newline.
+
+  initialize( p );
 }
 
 } // end namespace nupic

--- a/src/nupic/encoders/ScalarEncoder.cpp
+++ b/src/nupic/encoders/ScalarEncoder.cpp
@@ -28,10 +28,11 @@
 
 #include <algorithm> // std::min
 #include <numeric>   // std::iota
-#include <math.h>    // isnan
+#include <cmath>     // isnan
 #include <nupic/encoders/ScalarEncoder.hpp>
 
 namespace nupic {
+namespace encoders {
 
 ScalarEncoder::ScalarEncoder(ScalarEncoderParameters &parameters)
   { initialize( parameters ); }
@@ -45,18 +46,18 @@ void ScalarEncoder::initialize(ScalarEncoderParameters &parameters)
   if( parameters.active     > 0)    num_active_args++;
   if( parameters.sparsity   > 0.0f) num_active_args++;
   NTA_CHECK( num_active_args != 0u )
-      << "Missing argument: 'active' or 'sparsity'.";
+      << "Missing argument, need one of: 'active' or 'sparsity'.";
   NTA_CHECK( num_active_args == 1u )
-      << "Too many arguments, choose only one of 'active' or 'sparsity'.";
+      << "Too many arguments, choose only one of: 'active' or 'sparsity'.";
 
   UInt num_size_args = 0;
   if( parameters.size       > 0u)   num_size_args++;
   if( parameters.radius     > 0.0f) num_size_args++;
   if( parameters.resolution > 0.0f) num_size_args++;
   NTA_CHECK( num_size_args != 0u )
-      << "Missing argument, one of: 'size', 'radius', 'resolution'.";
+      << "Missing argument, need one of: 'size', 'radius', 'resolution'.";
   NTA_CHECK( num_size_args == 1u )
-      << "Too many arguments, choose only one of 'size', 'radius', 'resolution'.";
+      << "Too many arguments, choose only one of: 'size', 'radius', 'resolution'.";
 
   if( parameters.periodic ) {
     NTA_CHECK( not parameters.clipInput )
@@ -76,7 +77,7 @@ void ScalarEncoder::initialize(ScalarEncoderParameters &parameters)
   }
 
   // Determine resolution & size.
-  const double extentWidth = args_.maximum - args_.minimum;
+  const Real64 extentWidth = args_.maximum - args_.minimum;
   if( args_.size > 0u ) {
     // Distribute the active bits along the domain [minimum, maximum], including
     // the endpoints. The resolution is the width of each band between the
@@ -115,10 +116,10 @@ void ScalarEncoder::initialize(ScalarEncoderParameters &parameters)
   NTA_CHECK( args_.active < args_.size );
 
   // Initialize parent class.
-  BaseEncoder<double>::initialize({ args_.size });
+  BaseEncoder<Real64>::initialize({ args_.size });
 }
 
-void ScalarEncoder::encode(double input, SDR &output)
+void ScalarEncoder::encode(Real64 input, SDR &output)
 {
   // Check inputs
   NTA_CHECK( output.size == size );
@@ -194,4 +195,5 @@ void ScalarEncoder::load(std::istream &stream)
   initialize( p );
 }
 
+} // end namespace encoders
 } // end namespace nupic

--- a/src/nupic/encoders/ScalarEncoder.cpp
+++ b/src/nupic/encoders/ScalarEncoder.cpp
@@ -31,6 +31,11 @@
 
 namespace nupic {
 
+void ScalarEncoderBase::encode(Real input, SDR &output) {
+    NTA_CHECK( output.dimensions == dimensions );
+    output.setDense( encode(input) );
+}
+
 std::vector<UInt> ScalarEncoderBase::encode(Real input) {
     std::vector<UInt> output(getOutputWidth());
     encodeIntoArray(input, output.data());
@@ -65,6 +70,7 @@ ScalarEncoder::ScalarEncoder(int w, double minValue, double maxValue, int n,
     const int neededBuckets = neededBands + 1;
     n_ = neededBuckets + (w - 1);
   }
+  BaseEncoder<Real>::initialize({ (UInt) n_ });
   NTA_CHECK(bucketWidth_ > 0);
   NTA_CHECK(n_ > 0);
   NTA_CHECK(w_ < n_);
@@ -103,6 +109,7 @@ PeriodicScalarEncoder::PeriodicScalarEncoder(int w, double minValue,
     const int neededBuckets = (int)ceil((maxValue - minValue) / bucketWidth_);
     n_ = (neededBuckets > w_) ? neededBuckets : w_ + 1;
   }
+  BaseEncoder<Real>::initialize({ (UInt) n_ });
 
   NTA_CHECK(bucketWidth_ > 0);
   NTA_CHECK(n_ > 0);

--- a/src/nupic/encoders/ScalarEncoder.cpp
+++ b/src/nupic/encoders/ScalarEncoder.cpp
@@ -95,7 +95,12 @@ void ScalarEncoder::initialize(ScalarEncoderParameters &parameters)
 
     const int neededBands   = (int)ceil(extentWidth / args_.resolution);
     const int neededBuckets = neededBands + 1;
-    args_.size = neededBuckets + (args_.active - 1);
+    if( args_.periodic ) {
+      args_.size = neededBuckets - 1;
+    }
+    else {
+      args_.size = neededBuckets + (args_.active - 1);
+    }
   }
 
   // Determine radius.

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -113,6 +113,7 @@ namespace nupic {
   class ScalarEncoder : public BaseEncoder<double>
   {
   public:
+    ScalarEncoder() {};
     ScalarEncoder( ScalarEncoderParameters &parameters );
     void initialize( ScalarEncoderParameters &parameters );
 

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -44,8 +44,8 @@ namespace nupic {
      * Members "minimum" and "maximum" define the range of the input signal.
      * These endpoints are inclusive.
      */
-    double  minimum;
-    double  maximum;
+    double  minimum = 0.0f;
+    double  maximum = 0.0f;
 
     /**
      * Member "clipInput" determines whether to allow input values outside the
@@ -53,24 +53,24 @@ namespace nupic {
      * If true, the input will be clipped into the range [minimum, maximum].
      * If false, inputs outside of the range will raise an error.
      */
-    bool clipInput;
+    bool clipInput = false;
 
     /**
-     * TODO
+     * TODO DOCS
      */
-    bool periodic;
+    bool periodic = false;
 
     /**
      * Member "active" is the number of true bits in the encoded output SDR.
      * The output encodings will have a contiguous block of this many 1's.
      */
-    UInt active;
+    UInt active = 0u;
     /**
      * Member "sparsity" is an alternative way to specify the member "active".
      * Sparsity requires that the size to also be specified.
      * Specify only one: active or sparsity.
      */
-    Real sparsity;
+    Real sparsity = 0.0f;
 
     /**
      * These three (3) members define the total number of bits in the output:
@@ -85,7 +85,7 @@ namespace nupic {
     /**
      * Member "size" is the total number of bits in the encoded output SDR.
      */
-    UInt size;
+    UInt size = 0u;
 
     /**
      * Member "radius" Two inputs separated by more than the radius have
@@ -93,13 +93,13 @@ namespace nupic {
      * radius will in general overlap in at least some of their bits. You can
      * think of this as the radius of the input.
      */
-    double  radius;
+    double  radius = 0.0f;
 
     /**
      * Member "resolution" Two inputs separated by greater than, or equal to the
      * resolution are guaranteed to have different representations.
      */
-    double  resolution;
+    double  resolution = 0.0f;
   };
 
   /**
@@ -120,11 +120,10 @@ namespace nupic {
 
     void encode(double input, SDR &output) override;
 
-    ~ScalarEncoder() override {};
+    void save(std::ostream &stream) const override;
+    void load(std::istream &stream) override;
 
-    // TODO: save & load override
-    // TODO: REmember to zero the conflicting stuff out of the parameters so
-    // that it can be laoded via constructor.
+    ~ScalarEncoder() override {};
 
   private:
     ScalarEncoderParameters args_;

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -35,10 +35,6 @@
 namespace nupic {
 namespace encoders {
 
-  /**
-   * TODO, description
-   * TODO, example usage
-   */
   struct ScalarEncoderParameters
   {
     /**
@@ -57,7 +53,15 @@ namespace encoders {
     bool clipInput = false;
 
     /**
-     * TODO DOCS
+     * Member "periodic" controls what happens near the edges of the input
+     * range.
+     *
+     * If true, then the minimum & maximum input values are adjacent and the
+     * first and last bits of the output SDR are also adjacent.  The contiguous
+     * block of 1's wraps around the end back to the begining.
+     *
+     * If false, then minimum & maximum input values are the endpoints of the
+     * input range, are not adjacent, and activity does not wrap around.
      */
     bool periodic = false;
 
@@ -66,10 +70,11 @@ namespace encoders {
      * The output encodings will have a contiguous block of this many 1's.
      */
     UInt activeBits = 0u;
+
     /**
-     * Member "sparsity" is an alternative way to specify the member "active".
+     * Member "sparsity" is an alternative way to specify the member "activeBits".
      * Sparsity requires that the size to also be specified.
-     * Specify only one: active or sparsity.
+     * Specify only one of: activeBits or sparsity.
      */
     Real sparsity = 0.0f;
 
@@ -104,12 +109,15 @@ namespace encoders {
   };
 
   /**
-   * Encodes a real number as a contiguous block of 1s.
+   * Encodes a real number as a contiguous block of 1's.
    *
    * Description:
    * The ScalarEncoder encodes a numeric (floating point) value into an array
    * of bits. The output is 0's except for a contiguous block of 1's. The
    * location of this contiguous block varies continuously with the input value.
+   *
+   * TODO, Example Usage & unit test for it.
+   *
    */
   class ScalarEncoder : public BaseEncoder<Real64>
   {

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -116,15 +116,7 @@ namespace encoders {
   public:
     ScalarEncoder() {};
     ScalarEncoder( ScalarEncoderParameters &parameters );
-
-#ifdef __clang__
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Woverloaded-virtual"
-#endif
     void initialize( ScalarEncoderParameters &parameters );
-#ifdef __clang__
-  #pragma clang diagnostic pop
-#endif
 
     const ScalarEncoderParameters &parameters = args_;
 

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -62,10 +62,10 @@ namespace encoders {
     bool periodic = false;
 
     /**
-     * Member "active" is the number of true bits in the encoded output SDR.
+     * Member "activeBits" is the number of true bits in the encoded output SDR.
      * The output encodings will have a contiguous block of this many 1's.
      */
-    UInt active = 0u;
+    UInt activeBits = 0u;
     /**
      * Member "sparsity" is an alternative way to specify the member "active".
      * Sparsity requires that the size to also be specified.

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -33,6 +33,7 @@
 #include <nupic/encoders/BaseEncoder.hpp>
 
 namespace nupic {
+namespace encoders {
 
   /**
    * TODO, description
@@ -44,8 +45,8 @@ namespace nupic {
      * Members "minimum" and "maximum" define the range of the input signal.
      * These endpoints are inclusive.
      */
-    double  minimum = 0.0f;
-    double  maximum = 0.0f;
+    Real64 minimum = 0.0f;
+    Real64 maximum = 0.0f;
 
     /**
      * Member "clipInput" determines whether to allow input values outside the
@@ -93,13 +94,13 @@ namespace nupic {
      * radius will in general overlap in at least some of their bits. You can
      * think of this as the radius of the input.
      */
-    double  radius = 0.0f;
+    Real64 radius = 0.0f;
 
     /**
      * Member "resolution" Two inputs separated by greater than, or equal to the
      * resolution are guaranteed to have different representations.
      */
-    double  resolution = 0.0f;
+    Real64 resolution = 0.0f;
   };
 
   /**
@@ -110,7 +111,7 @@ namespace nupic {
    * of bits. The output is 0's except for a contiguous block of 1's. The
    * location of this contiguous block varies continuously with the input value.
    */
-  class ScalarEncoder : public BaseEncoder<double>
+  class ScalarEncoder : public BaseEncoder<Real64>
   {
   public:
     ScalarEncoder() {};
@@ -127,7 +128,7 @@ namespace nupic {
 
     const ScalarEncoderParameters &parameters = args_;
 
-    void encode(double input, SDR &output) override;
+    void encode(Real64 input, SDR &output) override;
 
     void save(std::ostream &stream) const override;
     void load(std::istream &stream) override;
@@ -137,5 +138,6 @@ namespace nupic {
   private:
     ScalarEncoderParameters args_;
   };   // end class ScalarEncoder
+}      // end namespace encoders
 }      // end namespace nupic
 #endif // end NTA_ENCODERS_SCALAR

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -31,13 +31,14 @@
 
 #include <nupic/types/Types.hpp>
 #include <nupic/utils/Log.hpp> //NTA_CHECK
+#include <nupic/encoders/BaseEncoder.hpp>
 
 namespace nupic {
 /**
  * @b Description
  * Base class for ScalarEncoders
  */
-  class ScalarEncoderBase
+  class ScalarEncoderBase : public BaseEncoder<Real>
   {
   public:
     virtual ~ScalarEncoderBase() {}
@@ -67,9 +68,11 @@ namespace nupic {
      */
     std::vector<UInt> encode(Real input);
 
+    void encode(Real input, SDR &output) override;
+
   protected: 
     ScalarEncoderBase(int w, int n):
-	 w_(w), n_(n) {
+        w_(w), n_(n) {
       NTA_CHECK(w > 0) << "EncoderBase: w must be > 0";
 //      NTA_CHECK(w < n) << "EncoderBase: w must be < n"; //not, because we can init with n=0 and eg resolution
     }

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -115,7 +115,15 @@ namespace nupic {
   public:
     ScalarEncoder() {};
     ScalarEncoder( ScalarEncoderParameters &parameters );
+
+#ifdef __clang__
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Woverloaded-virtual"
+#endif
     void initialize( ScalarEncoderParameters &parameters );
+#ifdef __clang__
+  #pragma clang diagnostic pop
+#endif
 
     const ScalarEncoderParameters &parameters = args_;
 

--- a/src/nupic/regions/ScalarSensor.cpp
+++ b/src/nupic/regions/ScalarSensor.cpp
@@ -40,7 +40,7 @@ namespace nupic {
 ScalarSensor::ScalarSensor(const ValueMap &params, Region *region)
     : RegionImpl(region) {
   params_.size = params.getScalarT<UInt32>("n");
-  params_.active = params.getScalarT<UInt32>("w");
+  params_.activeBits = params.getScalarT<UInt32>("w");
   params_.resolution = params.getScalarT<Real64>("resolution");
   params_.radius = params.getScalarT<Real64>("radius");
   params_.minimum = params.getScalarT<Real64>("minValue");

--- a/src/nupic/regions/ScalarSensor.cpp
+++ b/src/nupic/regions/ScalarSensor.cpp
@@ -47,7 +47,7 @@ ScalarSensor::ScalarSensor(const ValueMap &params, Region *region)
   params_.maximum = params.getScalarT<Real64>("maxValue");
   params_.periodic = params.getScalarT<bool>("periodic");
   params_.clipInput = params.getScalarT<bool>("clipInput");
-  encoder_ = new ScalarEncoder( params_ );
+  encoder_ = new encoders::ScalarEncoder( params_ );
 
   sensedValue_ = params.getScalarT<Real64>("sensedValue");
 }
@@ -226,7 +226,7 @@ void ScalarSensor::deserialize(BundleIO &bundle) {
   NTA_CHECK(tag == "~ScalerSensor");
   f.ignore(1);
 
-  encoder_ = new ScalarEncoder( params_ );
+  encoder_ = new encoders::ScalarEncoder( params_ );
 
   initialize();
   encodedOutput_->initialize();

--- a/src/nupic/regions/ScalarSensor.cpp
+++ b/src/nupic/regions/ScalarSensor.cpp
@@ -210,6 +210,7 @@ void ScalarSensor::serialize(BundleIO &bundle) {
     std::ostream &f = bundle.getOutputStream();
     f << "ScalerSensor ";
     f.write((char*)&params_, sizeof(params_));
+    f << " " << sensedValue_ << " ";
     f << "~ScalerSensor" << std::endl;
 }
 
@@ -220,6 +221,7 @@ void ScalarSensor::deserialize(BundleIO &bundle) {
   NTA_CHECK(tag == "ScalerSensor");
   f.ignore(1);
   f.read((char *)&params_, sizeof(params_));
+  f >> sensedValue_;
   f >> tag;
   NTA_CHECK(tag == "~ScalerSensor");
   f.ignore(1);
@@ -228,7 +230,6 @@ void ScalarSensor::deserialize(BundleIO &bundle) {
 
   initialize();
   encodedOutput_->initialize();
-  compute();
 }
 
 

--- a/src/nupic/regions/ScalarSensor.cpp
+++ b/src/nupic/regions/ScalarSensor.cpp
@@ -59,12 +59,8 @@ ScalarSensor::ScalarSensor(BundleIO &bundle, Region *region)
 
 void ScalarSensor::compute()
 {
-  UInt32* array = (UInt32*)encodedOutput_->getData().getBuffer();
-  SDR output( encoder_->dimensions );
-  encoder_->encode((Real)sensedValue_, output);
-  for(auto i = 0u; i < encoder_->size; ++i) {
-    array[i] = (UInt) output.getDense()[i];
-  }
+  SDR &output = encodedOutput_->getData().getSDR();
+  encoder_->encode((Real64)sensedValue_, output);
 }
 
 ScalarSensor::~ScalarSensor() { delete encoder_; }
@@ -147,7 +143,7 @@ ScalarSensor::~ScalarSensor() { delete encoder_; }
 
   /* ----- outputs ----- */
 
-  ns->outputs.add("encoded", OutputSpec("Encoded value", NTA_BasicType_UInt32,
+  ns->outputs.add("encoded", OutputSpec("Encoded value", NTA_BasicType_SDR,
                                         0,    // elementCount
                                         true, // isRegionLevel
                                         true  // isDefaultOutput

--- a/src/nupic/regions/ScalarSensor.hpp
+++ b/src/nupic/regions/ScalarSensor.hpp
@@ -71,9 +71,9 @@ public:
 
 private:
   Real64 sensedValue_;
-  ScalarEncoderParameters params_;
+  encoders::ScalarEncoderParameters params_;
 
-  ScalarEncoder *encoder_;
+  encoders::ScalarEncoder *encoder_;
   Output *encodedOutput_;
 };
 } // namespace nupic

--- a/src/nupic/regions/ScalarSensor.hpp
+++ b/src/nupic/regions/ScalarSensor.hpp
@@ -70,21 +70,11 @@ public:
   getNodeOutputElementCount(const std::string &outputName) const override;
 
 private:
-  struct {
-    Real64 sensedValue_;
-    Real64 resolution;
-    Real64 radius;
-    Real64 minValue;
-    Real64 maxValue;
-    UInt32 n;
-    UInt32 w;
-    bool periodic;
-    bool clipInput;
-  } params_;
+  Real64 sensedValue_;
+  ScalarEncoderParameters params_;
 
-  ScalarEncoderBase *encoder_;
+  ScalarEncoder *encoder_;
   Output *encodedOutput_;
-  Output *bucketOutput_;
 };
 } // namespace nupic
 

--- a/src/test/unit/encoders/ScalarEncoderTest.cpp
+++ b/src/test/unit/encoders/ScalarEncoderTest.cpp
@@ -62,10 +62,10 @@ void doScalarValueCases(ScalarEncoder& e, std::vector<ScalarValueCase> cases)
 
 TEST(ScalarEncoder, testClippingInputs) {
   ScalarEncoderParameters p;
-  p.size    = 10;
-  p.active  = 2;
-  p.minimum = 10;
-  p.maximum = 20;
+  p.size       = 10;
+  p.activeBits = 2;
+  p.minimum    = 10;
+  p.maximum    = 20;
 
   SDR output({ 10 });
   {
@@ -89,10 +89,10 @@ TEST(ScalarEncoder, testClippingInputs) {
 
 TEST(ScalarEncoder, ValidScalarInputs) {
   ScalarEncoderParameters p;
-  p.size    = 10;
-  p.active  = 2;
-  p.minimum = 10;
-  p.maximum = 20;
+  p.size       = 10;
+  p.activeBits = 2;
+  p.minimum    = 10;
+  p.maximum    = 20;
   SDR output({ 10 });
   ScalarEncoder e( p );
 
@@ -104,10 +104,10 @@ TEST(ScalarEncoder, ValidScalarInputs) {
 
 TEST(ScalarEncoder, NonIntegerBucketWidth) {
   ScalarEncoderParameters p;
-  p.size    = 7;
-  p.active  = 3;
-  p.minimum = 10.0;
-  p.maximum = 20.0;
+  p.size       = 7;
+  p.activeBits = 3;
+  p.minimum    = 10.0;
+  p.maximum    = 20.0;
   ScalarEncoder encoder( p );
 
   std::vector<ScalarValueCase> cases = {{10.0, {0, 1, 2}},
@@ -118,7 +118,7 @@ TEST(ScalarEncoder, NonIntegerBucketWidth) {
 
 TEST(ScalarEncoder, RoundToNearestMultipleOfResolution) {
   ScalarEncoderParameters p;
-  p.active     = 3;
+  p.activeBits = 3;
   p.minimum    = 10.0;
   p.maximum    = 20.0;
   p.resolution = 1;
@@ -145,7 +145,7 @@ TEST(ScalarEncoder, RoundToNearestMultipleOfResolution) {
 
 TEST(ScalarEncoder, PeriodicRoundNearestMultipleOfResolution) {
   ScalarEncoderParameters p;
-  p.active     = 3;
+  p.activeBits = 3;
   p.minimum    = 10.0;
   p.maximum    = 20.0;
   p.resolution = 1;
@@ -174,10 +174,10 @@ TEST(ScalarEncoder, PeriodicRoundNearestMultipleOfResolution) {
 TEST(ScalarEncoder, Serialization) {
   vector<ScalarEncoder*> inputs;
   ScalarEncoderParameters p;
-  p.minimum   = -1.234;
-  p.maximum   = 12.34;
-  p.active    = 34;
-  p.radius    = .1337;
+  p.minimum    = -1.234;
+  p.maximum    = 12.34;
+  p.activeBits = 34;
+  p.radius     = .1337;
   inputs.push_back( new ScalarEncoder( p ) );
   p.clipInput = true;
   inputs.push_back( new ScalarEncoder( p ) );
@@ -208,7 +208,7 @@ TEST(ScalarEncoder, Serialization) {
     const auto &p1 = enc1->parameters;
     const auto &p2 = enc2.parameters;
     EXPECT_EQ(  p1.size,       p2.size);
-    EXPECT_EQ(  p1.active,     p2.active);
+    EXPECT_EQ(  p1.activeBits, p2.activeBits);
     EXPECT_EQ(  p1.periodic,   p2.periodic);
     EXPECT_EQ(  p1.clipInput,  p2.clipInput);
     EXPECT_NEAR(p1.minimum,    p2.minimum,       1.0f / 100000 );

--- a/src/test/unit/encoders/ScalarEncoderTest.cpp
+++ b/src/test/unit/encoders/ScalarEncoderTest.cpp
@@ -68,6 +68,19 @@ void doScalarValueCases(ScalarEncoderBase& e, std::vector<ScalarValueCase> cases
             << "ACTUAL:" << std::endl
             << vec2str(actualOutput);
         }
+      // Check SDR overload method.
+      SDR out( e.dimensions );
+      e.encode(c->input, out );
+      actualOutput.assign( out.getDense().begin(), out.getDense().end() );
+      for (UInt i = 0; i < e.getOutputWidth(); i++)
+        {
+          EXPECT_EQ(c->expectedOutput[i], actualOutput[i])
+            << "For input " << c->input << " and index " << i << std::endl
+            << "EXPECTED:" << std::endl
+            << vec2str(c->expectedOutput) << std::endl
+            << "ACTUAL:" << std::endl
+            << vec2str(actualOutput);
+        }
     }
 }
 

--- a/src/test/unit/encoders/ScalarEncoderTest.cpp
+++ b/src/test/unit/encoders/ScalarEncoderTest.cpp
@@ -32,6 +32,11 @@
 
 using namespace nupic;
 
+TEST(ScalarEncoder, testExampleUsage) {
+  // TODO
+}
+
+
 struct ScalarValueCase
 {
   double input;
@@ -192,7 +197,7 @@ TEST(ScalarEncoder, Serialization) {
     x->save( buf );
   }
 
-  cerr << "buf " << buf.str() << endl;
+  // cerr << "SERIALIZED:" << endl << buf.str() << endl;
 
   for( const auto enc1 : inputs ) {
     ScalarEncoder enc2;
@@ -200,15 +205,15 @@ TEST(ScalarEncoder, Serialization) {
 
     const auto &p1 = enc1->parameters;
     const auto &p2 = enc2.parameters;
-    EXPECT_EQ(p1.size,       p2.size);
-    EXPECT_EQ(p1.active,     p2.active);
-    EXPECT_EQ(p1.periodic,   p2.periodic);
-    EXPECT_EQ(p1.clipInput,  p2.clipInput);
-    EXPECT_NEAR(p1.minimum,     p2.minimum,       1.0f / 10000000 );
-    EXPECT_NEAR(p1.maximum,     p2.maximum,       1.0f / 10000000 );
-    EXPECT_NEAR(p1.radius,      p2.radius,        1.0f / 10000000 );
-    EXPECT_NEAR(p1.resolution,  p2.resolution,    1.0f / 10000000 );
-    EXPECT_NEAR(p1.sparsity,    p2.sparsity,      1.0f / 10000000 );
+    EXPECT_EQ(  p1.size,       p2.size);
+    EXPECT_EQ(  p1.active,     p2.active);
+    EXPECT_EQ(  p1.periodic,   p2.periodic);
+    EXPECT_EQ(  p1.clipInput,  p2.clipInput);
+    EXPECT_NEAR(p1.minimum,    p2.minimum,       1.0f / 100000 );
+    EXPECT_NEAR(p1.maximum,    p2.maximum,       1.0f / 100000 );
+    EXPECT_NEAR(p1.resolution, p2.resolution,    1.0f / 100000 );
+    EXPECT_NEAR(p1.sparsity,   p2.sparsity,      1.0f / 100000 );
+    EXPECT_NEAR(p1.radius,     p2.radius,        1.0f / 100000 );
     delete enc1;
   }
 }

--- a/src/test/unit/encoders/ScalarEncoderTest.cpp
+++ b/src/test/unit/encoders/ScalarEncoderTest.cpp
@@ -31,6 +31,8 @@
 #include <vector>
 
 using namespace nupic;
+using nupic::encoders::ScalarEncoder;
+using nupic::encoders::ScalarEncoderParameters;
 
 TEST(ScalarEncoder, testExampleUsage) {
   // TODO
@@ -39,7 +41,7 @@ TEST(ScalarEncoder, testExampleUsage) {
 
 struct ScalarValueCase
 {
-  double input;
+  Real64 input;
   std::vector<UInt> expectedOutput; // Sparse indices of active bits.
 };
 

--- a/src/test/unit/encoders/ScalarEncoderTest.cpp
+++ b/src/test/unit/encoders/ScalarEncoderTest.cpp
@@ -1,8 +1,10 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
- * with Numenta, Inc., for a separate license for this software code, the
- * following terms and conditions apply:
+ * Copyright (C) 2016, Numenta, Inc.
+ *               2019, David McDougall
+ *
+ * Unless you have an agreement with Numenta, Inc., for a separate license for
+ * this software code, the following terms and conditions apply:
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero Public License version 3 as
@@ -21,198 +23,143 @@
  */
 
 /** @file
- * Unit tests for the ScalarEncoder and PeriodicScalarEncoder
+ * Unit tests for the ScalarEncoder
  */
 
 #include "gtest/gtest.h"
 #include <nupic/encoders/ScalarEncoder.hpp>
-#include <string>
 #include <vector>
 
 using namespace nupic;
 
-template <typename T> std::string vec2str(std::vector<T> vec) {
-  std::ostringstream oss("");
-  for (size_t i = 0; i < vec.size(); i++) //FIXME VectorHelper would have been used eg. here
-    oss << vec[i];
-  return oss.str();
-}
-
 struct ScalarValueCase
 {
-  Real32 input;
-  std::vector<UInt> expectedOutput;
+  double input;
+  std::vector<UInt> expectedOutput; // Sparse indices of active bits.
 };
 
-std::vector<UInt> patternFromNZ(int n, std::vector<size_t> patternNZ) //TODO use vectorHelpers sparseToDense
+void doScalarValueCases(ScalarEncoder& e, std::vector<ScalarValueCase> cases)
 {
-  auto v = std::vector<UInt>(n, 0);
-  for (auto it = patternNZ.begin(); it != patternNZ.end(); it++)
-    {
-      v[*it] = 1;
-    }
-  return v;
-}
+  for( auto c : cases )
+  {
+    SDR expectedOutput( e.dimensions );
+    expectedOutput.setSparse( c.expectedOutput );
 
-void doScalarValueCases(ScalarEncoderBase& e, std::vector<ScalarValueCase> cases)
-{
-  for (auto c = cases.begin(); c != cases.end(); c++)
-    {
-      auto actualOutput = e.encode(c->input);
-      for (UInt i = 0; i < e.getOutputWidth(); i++)
-        {
-          EXPECT_EQ(c->expectedOutput[i], actualOutput[i])
-            << "For input " << c->input << " and index " << i << std::endl
-            << "EXPECTED:" << std::endl
-            << vec2str(c->expectedOutput) << std::endl
-            << "ACTUAL:" << std::endl
-            << vec2str(actualOutput);
-        }
-      // Check SDR overload method.
-      SDR out( e.dimensions );
-      e.encode(c->input, out );
-      actualOutput.assign( out.getDense().begin(), out.getDense().end() );
-      for (UInt i = 0; i < e.getOutputWidth(); i++)
-        {
-          EXPECT_EQ(c->expectedOutput[i], actualOutput[i])
-            << "For input " << c->input << " and index " << i << std::endl
-            << "EXPECTED:" << std::endl
-            << vec2str(c->expectedOutput) << std::endl
-            << "ACTUAL:" << std::endl
-            << vec2str(actualOutput);
-        }
-    }
+    SDR actualOutput( e.dimensions );
+    e.encode( c.input, actualOutput );
+
+    EXPECT_EQ( actualOutput, expectedOutput );
+  }
 }
 
 
 TEST(ScalarEncoder, testClippingInputs) {
-  const int n = 10;
-  const int w = 2;
-  const double minValue = 10;
-  const double maxValue = 20;
-  const double radius = 0;
-  const double resolution = 0;
+  ScalarEncoderParameters p;
+  p.size    = 10;
+  p.active  = 2;
+  p.minimum = 10;
+  p.maximum = 20;
 
+  SDR output({ 10 });
   {
-    const bool clipInput = false;
-    ScalarEncoder e(w, minValue, maxValue, n, radius, resolution, clipInput);
+    p.clipInput = false;
+    ScalarEncoder e( p );
 
-    EXPECT_ANY_THROW(e.encode(9.9f));
-    EXPECT_NO_THROW(e.encode(10.0f));
-    EXPECT_NO_THROW(e.encode(20.0f));
-    EXPECT_ANY_THROW(e.encode(20.1f));
+    EXPECT_ANY_THROW(e.encode( 9.9f, output));
+    EXPECT_NO_THROW( e.encode(10.0f, output));
+    EXPECT_NO_THROW( e.encode(20.0f, output));
+    EXPECT_ANY_THROW(e.encode(20.1f, output));
   }
 
   {
-    const bool clipInput = true;
-    ScalarEncoder e(w, minValue, maxValue, n, radius, resolution, clipInput);
+    p.clipInput = true;
+    ScalarEncoder e( p );
 
-    EXPECT_NO_THROW(e.encode(9.9f));
-    EXPECT_NO_THROW(e.encode(20.1f));
+    EXPECT_NO_THROW(e.encode( 9.9f, output));
+    EXPECT_NO_THROW(e.encode(20.1f, output));
   }
 }
 
-TEST(PeriodicScalarEncoder, ValidScalarInputs) {
-  const int n = 10;
-  const int w = 2;
-  const double minValue = 10;
-  const double maxValue = 20;
-  const double radius = 0;
-  const double resolution = 0;
-  PeriodicScalarEncoder e(w, minValue, maxValue, n, radius, resolution);
+TEST(ScalarEncoder, ValidScalarInputs) {
+  ScalarEncoderParameters p;
+  p.size    = 10;
+  p.active  = 2;
+  p.minimum = 10;
+  p.maximum = 20;
+  SDR output({ 10 });
+  ScalarEncoder e( p );
 
-  EXPECT_ANY_THROW(e.encode(9.9f));
-  EXPECT_NO_THROW(e.encode(10.0f));
-  EXPECT_NO_THROW(e.encode(19.9f));
-  EXPECT_ANY_THROW(e.encode(20.0f));
+  EXPECT_ANY_THROW(e.encode( 9.9f, output));
+  EXPECT_NO_THROW( e.encode(10.0f, output));
+  EXPECT_NO_THROW( e.encode(19.9f, output));
+  EXPECT_ANY_THROW(e.encode(20.0001f, output));
 }
 
 TEST(ScalarEncoder, NonIntegerBucketWidth) {
-  const int n = 7;
-  const int w = 3;
-  const double minValue = 10.0;
-  const double maxValue = 20.0;
-  const double radius = 0;
-  const double resolution = 0;
-  const bool clipInput = false;
-  ScalarEncoder encoder(w, minValue, maxValue, n, radius, resolution,
-                        clipInput);
+  ScalarEncoderParameters p;
+  p.size    = 7;
+  p.active  = 3;
+  p.minimum = 10.0;
+  p.maximum = 20.0;
+  ScalarEncoder encoder( p );
 
-  std::vector<ScalarValueCase> cases = {{10.0, patternFromNZ(n, {0, 1, 2})},
-                                        {20.0, patternFromNZ(n, {4, 5, 6})}};
-
-  doScalarValueCases(encoder, cases);
-}
-
-TEST(PeriodicScalarEncoder, NonIntegerBucketWidth) {
-  const int n = 7;
-  const int w = 3;
-  const double minValue = 10.0;
-  const double maxValue = 20.0;
-  const double radius = 0;
-  const double resolution = 0;
-  PeriodicScalarEncoder encoder(w, minValue, maxValue, n, radius, resolution);
-
-  std::vector<ScalarValueCase> cases = {{10.0f, patternFromNZ(n, {6, 0, 1})},
-                                        {19.9f, patternFromNZ(n, {5, 6, 0})}};
+  std::vector<ScalarValueCase> cases = {{10.0, {0, 1, 2}},
+                                        {20.0, {4, 5, 6}}};
 
   doScalarValueCases(encoder, cases);
 }
 
 TEST(ScalarEncoder, RoundToNearestMultipleOfResolution) {
-  const int n_in = 0;
-  const int w = 3;
-  const double minValue = 10.0;
-  const double maxValue = 20.0;
-  const double radius = 0;
-  const double resolution = 1;
-  const bool clipInput = false;
-  ScalarEncoder encoder(w, minValue, maxValue, n_in, radius, resolution, clipInput);
+  ScalarEncoderParameters p;
+  p.active     = 3;
+  p.minimum    = 10.0;
+  p.maximum    = 20.0;
+  p.resolution = 1;
+  ScalarEncoder encoder( p );
 
-  const unsigned int n = 13u;
-  ASSERT_EQ(n, encoder.getOutputWidth());
+  ASSERT_EQ(encoder.parameters.size, 13u);
 
   std::vector<ScalarValueCase> cases = {
-      {10.00f, patternFromNZ(n, {0, 1, 2})},
-      {10.49f, patternFromNZ(n, {0, 1, 2})},
-      {10.50f, patternFromNZ(n, {1, 2, 3})},
-      {11.49f, patternFromNZ(n, {1, 2, 3})},
-      {11.50f, patternFromNZ(n, {2, 3, 4})},
-      {14.49f, patternFromNZ(n, {4, 5, 6})},
-      {14.50f, patternFromNZ(n, {5, 6, 7})},
-      {15.49f, patternFromNZ(n, {5, 6, 7})},
-      {15.50f, patternFromNZ(n, {6, 7, 8})},
-      {19.49f, patternFromNZ(n, {9, 10, 11})},
-      {19.50f, patternFromNZ(n, {10, 11, 12})},
-      {20.00f, patternFromNZ(n, {10, 11, 12})}};
+      {10.00f, {0, 1, 2}},
+      {10.49f, {0, 1, 2}},
+      {10.50f, {1, 2, 3}},
+      {11.49f, {1, 2, 3}},
+      {11.50f, {2, 3, 4}},
+      {14.49f, {4, 5, 6}},
+      {14.50f, {5, 6, 7}},
+      {15.49f, {5, 6, 7}},
+      {15.50f, {6, 7, 8}},
+      {19.49f, {9, 10, 11}},
+      {19.50f, {10, 11, 12}},
+      {20.00f, {10, 11, 12}}};
 
   doScalarValueCases(encoder, cases);
 }
 
-TEST(PeriodicScalarEncoder, FloorToNearestMultipleOfResolution) {
-  const int n_in = 0;
-  const int w = 3;
-  const double minValue = 10.0;
-  const double maxValue = 20.0;
-  const double radius = 0;
-  const double resolution = 1;
-  PeriodicScalarEncoder encoder(w, minValue, maxValue, n_in, radius,
-                                resolution);
+TEST(ScalarEncoder, PeriodicRoundNearestMultipleOfResolution) {
+  ScalarEncoderParameters p;
+  p.active     = 3;
+  p.minimum    = 10.0;
+  p.maximum    = 20.0;
+  p.resolution = 1;
+  p.periodic   = true;
+  ScalarEncoder encoder( p );
 
-  const unsigned int n = 10u;
-  ASSERT_EQ(n, encoder.getOutputWidth());
+  ASSERT_EQ(encoder.parameters.size, 10u);
 
-  std::vector<ScalarValueCase> cases = {{10.00f, patternFromNZ(n, {9, 0, 1})},
-                                        {10.99f, patternFromNZ(n, {9, 0, 1})},
-                                        {11.00f, patternFromNZ(n, {0, 1, 2})},
-                                        {11.99f, patternFromNZ(n, {0, 1, 2})},
-                                        {12.00f, patternFromNZ(n, {1, 2, 3})},
-                                        {14.00f, patternFromNZ(n, {3, 4, 5})},
-                                        {14.99f, patternFromNZ(n, {3, 4, 5})},
-                                        {15.00f, patternFromNZ(n, {4, 5, 6})},
-                                        {15.99f, patternFromNZ(n, {4, 5, 6})},
-                                        {19.00f, patternFromNZ(n, {8, 9, 0})},
-                                        {19.99f, patternFromNZ(n, {8, 9, 0})}};
+  std::vector<ScalarValueCase> cases = {
+      {10.00f, {0, 1, 2}},
+      {10.49f, {0, 1, 2}},
+      {10.50f, {1, 2, 3}},
+      {11.49f, {1, 2, 3}},
+      {11.50f, {2, 3, 4}},
+      {14.49f, {4, 5, 6}},
+      {14.50f, {5, 6, 7}},
+      {15.49f, {5, 6, 7}},
+      {15.50f, {6, 7, 8}},
+      {19.49f, {9, 0, 1}},
+      {19.50f, {0, 1, 2}},
+      {20.00f, {0, 1, 2}}};
 
   doScalarValueCases(encoder, cases);
 }

--- a/src/test/unit/regions/SPRegionTest.cpp
+++ b/src/test/unit/regions/SPRegionTest.cpp
@@ -311,7 +311,7 @@ TEST(SPRegionTest, testSerialization)
 	  try {
 
 		  VERBOSE << "Setup first network and save it" << std::endl;
-      std::shared_ptr<Region> n1region1 = net1->addRegion("region1", "ScalarSensor", "{n: 100,w: 10,minValue: 0,maxValue: 10}");
+      std::shared_ptr<Region> n1region1 = net1->addRegion("region1", "ScalarSensor", "{n: 100,w: 10,minValue: 1,maxValue: 10}");
       std::shared_ptr<Region> n1region2 = net1->addRegion("region2", "SPRegion", "{columnCount: 200}");
       net1->link("region1", "region2", "UniformLink", "", "encoded", "bottomUpIn");
       net1->initialize();

--- a/src/test/unit/regions/TMRegionTest.cpp
+++ b/src/test/unit/regions/TMRegionTest.cpp
@@ -339,7 +339,7 @@ TEST(TMRegionTest, testSerialization) {
 
     VERBOSE << "Setup first network and save it" << std::endl;
     std::shared_ptr<Region> n1region1 = net1->addRegion( "region1", "ScalarSensor",
-                                             "{n: 48,w: 10,minValue: 0,maxValue: 10}");
+                                             "{n: 48,w: 10,minValue: 0.05,maxValue: 10}");
     n1region1->setParameterReal64("sensedValue", 5.0);
 
     std::shared_ptr<Region> n1region2 =  net1->addRegion("region2", "TMRegion", "{numberOfCols: 48}");


### PR DESCRIPTION
See issue #291 

TODO:
- [x] Decide if we should force all encoders to implement serialization
    - [x] Add serializable interface & implement it for all encoders in master branch (ScalarEnc)
- [ ] Documentation
    - [x] C++ docs, cleanup & proof read
    - [x] Python docs
    - [ ] C++ example usage & unit test for example
    - [ ] Python example usage & unit test for example
- [x] Python bindings, convenience & compatibility  methods:
    - [ ] ~getWidth~ Won't fix
    - [ ] ~encodeIntoArray~ Won't fix
    - [x] encode(input) -> SDR
- [x] Document changes to the ScalarEncoder API in the API_ChangeLog