### PR TITLE
SDR replaces VectorHelpers

### DIFF
--- a/bindings/py/cpp_src/bindings/algorithms/py_SDR.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_SDR.cpp
@@ -169,7 +169,7 @@ current value.)");
                 for(auto dim = 0u; dim < self.dimensions.size(); dim++) {
                     NTA_CHECK( (UInt) buf.shape[dim] == self.dimensions[dim] );
                 }
-                Byte *data = (Byte*) buf.ptr;
+                UInt *data = (UInt*) buf.ptr;
                 if( data == self.getDense().data() )
                     // We got our own data back, set inplace instead of copying.
                     self.setDense( self.getDense() );

--- a/src/examples/hotgym/HelloSPTP.cpp
+++ b/src/examples/hotgym/HelloSPTP.cpp
@@ -118,6 +118,7 @@ Real64 BenchmarkHotgym::run(UInt EPOCHS, bool useSPlocal, bool useSPglobal, bool
     enc.encodeIntoArray(r, input.getSparse().data());
     input.setSparseInplace(); //update SDR
     tEnc.stop();
+    cout << "OK" << endl;
 
     //SP (global x local) 
     if(useSPlocal) {

--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -32,14 +32,12 @@
 #include <nupic/algorithms/SpatialPooler.hpp>
 #include <nupic/math/Topology.hpp>
 #include <nupic/math/Math.hpp> // nupic::Epsilon
-#include <nupic/utils/VectorHelpers.hpp>
 
 #define VERSION 2  // version for stream serialization
 
 using namespace nupic;
 using nupic::algorithms::spatial_pooler::SpatialPooler;
 using namespace nupic::math::topology;
-using nupic::utils::VectorHelpers;
 
 // Round f to 5 digits of precision. This is used to set
 // permanence values and help avoid small amounts of drift between
@@ -465,8 +463,8 @@ void SpatialPooler::initialize(
     connections_.createSegment( (connections::CellIdx)i );
 
     // Note: initMapPotential_ & initPermanence_ return dense arrays.
-    vector<UInt> potential = initMapPotential_((UInt)i, wrapAround_);
-    vector<Real> perm = initPermanence_(potential, initConnectedPct_);
+    const vector<UInt> potential = initMapPotential_((UInt)i, wrapAround_);
+    const vector<Real> perm = initPermanence_(potential, initConnectedPct_);
     for(UInt presyn = 0; presyn < numInputs_; presyn++) {
       if( potential[presyn] )
         connections_.createSynapse( (connections::Segment)i, presyn, perm[presyn] );
@@ -569,8 +567,9 @@ vector<UInt> SpatialPooler::initMapPotential_(UInt column, bool wrapAround) {
 
   const UInt numPotential = (UInt)round(columnInputs.size() * potentialPct_);
   const auto selectedInputs = rng_.sample<UInt>(columnInputs, numPotential);
-  const vector<UInt> potential = VectorHelpers::sparseToBinary<UInt>(selectedInputs, numInputs_);
-  return potential;
+  SDR potential( {numInputs_} );
+  potential.setSparse(selectedInputs);
+  return potential.getDense();
 }
 
 

--- a/src/nupic/types/Sdr.cpp
+++ b/src/nupic/types/Sdr.cpp
@@ -339,9 +339,9 @@ namespace nupic {
         }
         // Check data
         return std::equal(
-            getDense().begin(),
-            getDense().end(), 
-            sdr.getDense().begin());
+            getSparse().begin(),
+            getSparse().end(), 
+            sdr.getSparse().begin());
     }
 
 

--- a/src/nupic/types/Sdr.hpp
+++ b/src/nupic/types/Sdr.hpp
@@ -172,27 +172,6 @@ protected:
     void do_callbacks() const;
 
     /**
-     * Update the SDR to reflect the value currently inside of the dense array.
-     * Use this method after modifying the dense buffer inplace, in order to
-     * propigate any changes to the sparse & coordinate formats.
-     */
-    virtual void setDenseInplace() const;
-
-    /**
-     * Update the SDR to reflect the value currently inside of the flatSparse
-     * vector. Use this method after modifying the flatSparse vector inplace, in
-     * order to propigate any changes to the dense & coordinate formats.
-     */
-    virtual void setSparseInplace() const;
-
-    /**
-     * Update the SDR to reflect the value currently inside of the sparse
-     * vector. Use this method after modifying the sparse vector inplace, in
-     * order to propigate any changes to the dense & sparse formats.
-     */
-    virtual void setCoordinatesInplace() const;
-
-    /**
      * Destroy this SDR.  Makes SDR unusable, should error or clearly fail if
      * used.  Also sends notification to all watchers via destroyCallbacks.
      * This is a separate method from ~SDR so that SDRs can be destroyed long
@@ -391,6 +370,27 @@ public:
      * the true values in the SDR.
      */
     virtual SDR_coordinate_t& getCoordinates() const;
+
+    /**
+     * Update the SDR to reflect the value currently inside of the dense array.
+     * Use this method after modifying the dense buffer inplace, in order to
+     * propigate any changes to the sparse & coordinate formats.
+     */
+    virtual void setDenseInplace() const;
+
+    /**
+     * Update the SDR to reflect the value currently inside of the flatSparse
+     * vector. Use this method after modifying the flatSparse vector inplace, in
+     * order to propigate any changes to the dense & coordinate formats.
+     */
+    virtual void setSparseInplace() const;
+
+    /**
+     * Update the SDR to reflect the value currently inside of the sparse
+     * vector. Use this method after modifying the sparse vector inplace, in
+     * order to propigate any changes to the dense & sparse formats.
+     */
+    virtual void setCoordinatesInplace() const;
 
     /**
      * Deep Copy the given SDR to this SDR.  This overwrites the current value of

--- a/src/nupic/types/Sdr.hpp
+++ b/src/nupic/types/Sdr.hpp
@@ -35,7 +35,7 @@ using namespace std;
 
 namespace nupic {
 
-typedef vector<Byte>          SDR_dense_t;
+typedef vector<UInt>          SDR_dense_t; //TODO add templated types for SDR<DenseElemT, SparseElemT, CoordElemT> + default SDR<Byte, UInt, UInt> 
 typedef vector<UInt>          SDR_sparse_t;
 typedef vector<vector<UInt>>  SDR_coordinate_t;
 typedef function<void()>      SDR_callback_t;

--- a/src/nupic/types/SdrProxy.hpp
+++ b/src/nupic/types/SdrProxy.hpp
@@ -284,19 +284,19 @@ public:
         if( !dense_valid_lazy ) {
             // Setup for copying the data as rows & strides.
             const UInt    n_dim = (UInt)inputs[0]->dimensions.size();
-            vector<Byte*> buffers;
+            vector<UInt*> buffers;
             vector<UInt>  row_lengths;
             for(const auto &sdr : inputs) {
                 buffers.push_back( sdr->getDense().data() );
-                UInt row = 1u;
-                for(UInt d = axis; d < n_dim; ++d)
-                    row *= sdr->dimensions[d];
-                row_lengths.push_back( row );
+                UInt dimProduct = 1u;
+                for(const auto dimAxis : sdr->dimensions)
+                    dimProduct *= dimAxis;
+                row_lengths.push_back( dimProduct );
             }
             // Get the output buffer.
             dense_.resize( size );
-                  Byte *dense_data = dense_.data();
-            const Byte *data_end   = dense_data + size;
+            auto  dense_data       = dense_.data();
+            const auto data_end    = dense_data + size;
             const auto n_inputs    = inputs.size();
             while( dense_data < data_end ) {
                 // Copy one row from each input SDR.


### PR DESCRIPTION
I want to replace some/most functionality of VectorHelpers by SDR. 

- [x] SP uses SDR
- [x] Hotgym uses SDR
- [ ] make SDR_dense_t templated 
- [ ] remove VectorHelpers::sparseToBinary, binaryToSparse
 