### PR TITLE
Fixes the dependancies for air-gap computers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ After that completes you are all set to run your .py programs which import the e
  * nupic.bindings.algorithms
  * nupic.bindings.engine_internal
  * nupic.bindings.math
+ * nupic.bindings.encoders
+ * nupic.bindings.sdr
  
 The installation scripts will automatically download and build the dependancies it needs.
  * Boost   (Not needed by C++17 compilers that support the filesystem module)
@@ -106,8 +108,27 @@ The installation scripts will automatically download and build the dependancies 
  * Eigen
  * PyBind11
  * gtest
+ * mnist data (optional)
  * numpy
  * pytest
+ 
+ If you are installing on an air-gap computer (one without internet) then you can 
+ manually download the dependancies.  On another computer, download the distribution
+ packages as listed and rename them as indicated. Copy these to
+  `${REPOSITORY_DIR}/build/ThirdParty/share` on the target machine.
+  
+ | Name to give it | Where to obtain it |
+ | :-------------- | :----------------- |
+ | yaml-cpp.zip  *note1 | https://github.com/jbeder/yaml-cpp/archive/master.zip |
+ | boost.tar.gz  *note2 | https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz |
+ | eigen.tar.bz2        | http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2 |
+ | googletest.tar.gz    | https://github.com/abseil/googletest/archive/release-1.8.1.tar.gz |
+ | mnist.zip     *note3 | https://github.com/wichtounet/mnist/archive/master.zip |
+ | pybind11.tar.gz      | https://github.com/pybind/pybind11/archive/v2.2.4.tar.gz |
+ 
+ *note1: Version 0.6.2 of yaml-cpp is broken so use the master from the repository.
+ *note2: Boost is not required for Windows (MSVC 2017) or any compiler that supports C++17 with std::filesystem.
+ *note3: Data used for demo. Not required.
  
 #### Simple Build On Linux or OSX for C++ apps
  

--- a/external/Boost.cmake
+++ b/external/Boost.cmake
@@ -35,12 +35,10 @@
 #
 #######################################
 
-if(EXISTS ${REPOSITORY_DIR}/build/ThirdParty/share/boost_1_69_0.tar.gz)
-    set(BOOST_URL ${REPOSITORY_DIR}/build/ThirdParty/share/boost_1_69_0.tar.gz)
-    set(BOOST_HASH "9a2c2819310839ea373f42d69e733c339b4e9a19deab6bfec448281554aa4dbb")
+if(EXISTS "${REPOSITORY_DIR}/build/ThirdParty/share/boost.tar.gz")
+    set(BOOST_URL "${REPOSITORY_DIR}/build/ThirdParty/share/boost.tar.gz")
 else()
     set(BOOST_URL "https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz")
-    set(BOOST_HASH "9a2c2819310839ea373f42d69e733c339b4e9a19deab6bfec448281554aa4dbb")
 endif()
 
 # Download the boost distribution (at configure time).
@@ -54,7 +52,6 @@ include(DownloadProject/DownloadProject.cmake)
 download_project(PROJ Boost_download
 	PREFIX ${EP_BASE}/boost
 	URL ${BOOST_URL}
-	URL_HASH SHA256=${BOOST_HASH}
 	UPDATE_DISCONNECTED 1
 	QUIET
 	)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -24,12 +24,8 @@
 #  - Isolated so does not require being downloaded more than once.
 #
 #  - It is possible to manually preload the distribution packages (for air gap computers)
-#     1) On some other machine, download the following:
-#        https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz
-#        https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.6.2.tar.gz
-#        https://github.com/pybind/pybind11/archive/v2.2.4.tar.gz
-#        https://github.com/abseil/googletest/archive/release-1.8.1.tar.gz
-#        http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2
+#     1) On some other machine, download the distribution packages.
+#        See README.md for list of packages.
 #     2) copy these to <repository>/build/ThirdParty/share/
 #
 #  NOTE:  This is executed by the top level CMakeLists.txt via the bootstrap.cmake
@@ -62,6 +58,7 @@ endif()
 add_compile_options(${EXTERNAL_CXX_FLAGS})
 
 message(STATUS "external import")
+message(STATUS "   REPOSITORY_DIR        = ${REPOSITORY_DIR}")
 message(STATUS "   CMAKE_INSTALL_PREFIX  = ${CMAKE_INSTALL_PREFIX}")
 message(STATUS "   CMAKE_BUILD_TYPE      = ${CMAKE_BUILD_TYPE}")
 message(STATUS "   EXTERNAL_CXX_FLAGS    = ${EXTERNAL_CXX_FLAGS}")

--- a/external/YamlCppLib.cmake
+++ b/external/YamlCppLib.cmake
@@ -20,21 +20,20 @@
 # -----------------------------------------------------------------------------
 # Note: yaml-cpp includes an older version of gtest so 
 #       turn off YAML_CPP_BUILD_TESTS to prevent it from building gtest.
-
-if(EXISTS ${REPOSITORY_DIR}/build/ThirdParty/share/yaml-cpp-0.6.2.tar.gz)
-    set(URL ${REPOSITORY_DIR}/build/ThirdParty/share/yaml-cpp-0.6.2.tar.gz)
+message(STATUS "${REPOSITORY_DIR}/build/ThirdParty/share/yaml-cpp.zip")
+if(EXISTS "${REPOSITORY_DIR}/build/ThirdParty/share/yaml-cpp.zip")
+    set(URL "${REPOSITORY_DIR}/build/ThirdParty/share/yaml-cpp.zip")
 else()
     #set(URL https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.6.2.tar.gz)
-    set(REPO https://github.com/jbeder/yaml-cpp.git)
+    # There seems to be something wrong with the 0.6.2 distribution.  Use the master.
+    set(URL https://github.com/jbeder/yaml-cpp/archive/master.zip)
 endif()
 
-message(STATUS "Obtaining yaml-cpp")
+message(STATUS "Obtaining yaml-cpp from ${URL}" )
 include(DownloadProject/DownloadProject.cmake)
 download_project(PROJ yaml-cpp
 	PREFIX ${EP_BASE}/yaml-cpp
-	#URL ${URL}
-	GIT_REPOSITORY ${REPO}
-	GIT_SHALLOW ON
+	URL ${URL}
 	UPDATE_DISCONNECTED 1
 	QUIET
 	)

--- a/external/bootstrap.cmake
+++ b/external/bootstrap.cmake
@@ -39,6 +39,7 @@ execute_process(COMMAND ${CMAKE_COMMAND}
                         -D NEEDS_BOOST:BOOL=${NEEDS_BOOST}
                         -D BINDING_BUILD:STRING=${BINDING_BUILD}
 			-D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+			-D REPOSITORY_DIR=${REPOSITORY_DIR}
 			 ../../external
                 WORKING_DIRECTORY ${REPOSITORY_DIR}/build/ThirdParty
                 RESULT_VARIABLE result

--- a/external/eigen.cmake
+++ b/external/eigen.cmake
@@ -21,8 +21,8 @@
 
 # Fetch Eigen from GitHub archive
 #
-if(EXISTS ${REPOSITORY_DIR}/build/ThirdParty/share/eigen-eigen-323c052e1731.tar.bz2)
-    set(URL ${REPOSITORY_DIR}/build/ThirdParty/share/eigen-eigen-323c052e1731.tar.bz2)
+if(EXISTS "${REPOSITORY_DIR}/build/ThirdParty/share/eigen.tar.bz2")
+    set(URL "${REPOSITORY_DIR}/build/ThirdParty/share/eigen.tar.bz2")
 else()
     set(URL http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2)
 endif()

--- a/external/gtest.cmake
+++ b/external/gtest.cmake
@@ -29,14 +29,14 @@
 # Summary of tuple support for Microsoft Visual Studio:
 # Compiler    version(MS)  version(cmake)  Support
 # ----------  -----------  --------------  -----------------------------
-# <= VS 2010  <= 10        <= 1600         Use Google Tests's own tuple.
-# VS 2012     11           1700            std::tr1::tuple + _VARIADIC_MAX=10
-# VS 2013     12           1800            std::tr1::tuple
-# VS 2015     14           1900            std::tuple
-# VS 2017     15           >= 1910         std::tuple
+# <= VS 2010  <= 10        <= 1.6.0.0         Use Google Tests's own tuple.
+# VS 2012     11           1.7.0.0            std::tr1::tuple + _VARIADIC_MAX=10
+# VS 2013     12           1.8.0.0            std::tr1::tuple
+# VS 2015     14           1.9.0.0            std::tuple
+# VS 2017     15           >= 1.9.1.0         std::tuple
 
-if(EXISTS ${REPOSITORY_DIR}/build/ThirdParty/share/googletest-release-1.8.1.tar.gz)
-    set(URL ${REPOSITORY_DIR}/build/ThirdParty/share/googletest-release-1.8.1.tar.gz)
+if(EXISTS "${REPOSITORY_DIR}/build/ThirdParty/share/googletest.tar.gz")
+    set(URL "${REPOSITORY_DIR}/build/ThirdParty/share/googletest.tar.gz")
 else()
     set(URL https://github.com/abseil/googletest/archive/release-1.8.1.tar.gz)
 endif()
@@ -48,7 +48,7 @@ message(STATUS "Obtaining gtest")
 include(DownloadProject/DownloadProject.cmake)
 download_project(PROJ googletest
 	PREFIX ${EP_BASE}/gtest
-	URL https://github.com/abseil/googletest/archive/release-1.8.1.tar.gz
+	URL ${URL}
 	UPDATE_DISCONNECTED 1
 	QUIET
 	)

--- a/external/mnist_data.cmake
+++ b/external/mnist_data.cmake
@@ -21,11 +21,11 @@
 
 # Fetch MNIST dataset from online archive
 #
-if(EXISTS ${REPOSITORY_DIR}/build/ThirdParty/share/mnist.zip)
-    set(URL ${REPOSITORY_DIR}/build/ThirdParty/share/mnist.zip)
+if(EXISTS "${REPOSITORY_DIR}/build/ThirdParty/share/mnist.zip")
+    set(URL "${REPOSITORY_DIR}/build/ThirdParty/share/mnist.zip")
 else()
     set(URL "https://github.com/wichtounet/mnist/archive/master.zip")
-    set(HASH "855cb8c60f84e2fc6bea08c4a9df9a3cbd6230bddc55def635a938665c512ffc")
+    #set(HASH "855cb8c60f84e2fc6bea08c4a9df9a3cbd6230bddc55def635a938665c512ffc")
 endif()
 
 message(STATUS "obtaining MNIST data")
@@ -33,10 +33,11 @@ include(DownloadProject/DownloadProject.cmake)
 download_project(PROJ mnist
 	PREFIX ${EP_BASE}/mnist_data
 	URL    ${URL}
-	URL_HASH SHA256=${HASH}
+	#URL_HASH SHA256=${HASH}
     UPDATE_DISCONNECTED 1
 #    QUIET
    )	
+# Note: no check for failure.  This package is optional.
    
 # No build. This is a data only package
 # But we do need to run its CMakeLists.txt to unpack the files.

--- a/external/pybind11.cmake
+++ b/external/pybind11.cmake
@@ -21,8 +21,8 @@
 
 # Fetch pybind11 from GitHub archive
 #
-if(EXISTS ${REPOSITORY_DIR}/build/ThirdParty/share/pybind11-2.2.4.tar.gz)
-    set(URL ${REPOSITORY_DIR}/build/ThirdParty/share/pybind11-2.2.4.tar.gz)
+if(EXISTS "${REPOSITORY_DIR}/build/ThirdParty/share/pybind11.tar.gz")
+    set(URL "${REPOSITORY_DIR}/build/ThirdParty/share/pybind11.tar.gz")
 else()
     set(URL https://github.com/pybind/pybind11/archive/v2.2.4.tar.gz)
 endif()
@@ -35,6 +35,7 @@ download_project(PROJ pybind11
 	UPDATE_DISCONNECTED 1
 	QUIET
 	)
+# Note: no check for failure.  This is optional if not doing Python.
 	
 # No build. This is a header only package
 


### PR DESCRIPTION
I turned off my internet and used the README.md procedures to install nupic.cpp.  I found several things that were not quite right.  It now installs and the README.md file was updated.