### PR TITLE
New script rf_view_ScalarEncoder.py

### DIFF
--- a/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
@@ -99,13 +99,19 @@ The ScalarEncoder encodes a numeric (floating point) value into an array of
 bits. The output is 0's except for a contiguous block of 1's. The location of
 this contiguous block varies continuously with the input value.
 
-TODO, Example Usage & unit test for it.)");
+For help or to examine this run:
+$ python -m nupic.examples.rf_view_ScalarEncoder --help.)");
 
     py_ScalarEnc.def(py::init<ScalarEncoderParameters&>(), R"()");
     py_ScalarEnc.def_property_readonly("parameters",
         [](const ScalarEncoder &self) { return self.parameters; },
 R"(Contains the parameter structure which this encoder uses internally. All
 fields are filled in automatically.)");
+
+    py_ScalarEnc.def_property_readonly("dimensions",
+        [](const ScalarEncoder &self) { return self.dimensions; });
+    py_ScalarEnc.def_property_readonly("size",
+        [](const ScalarEncoder &self) { return self.size; });
 
     py_ScalarEnc.def("encode", &ScalarEncoder::encode, R"()");
 

--- a/bindings/py/packaging/src/nupic/examples/rf_view_ScalarEncoder.py
+++ b/bindings/py/packaging/src/nupic/examples/rf_view_ScalarEncoder.py
@@ -1,0 +1,109 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2019, David McDougall
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+# ----------------------------------------------------------------------
+
+"""
+Simple program to examine the ScalarEncoder.
+
+For help using this program run:
+$ python -m nupic.examples.rf_view_ScalarEncoder --help
+"""
+
+from nupic.bindings.encoders import ScalarEncoderParameters, ScalarEncoder
+from nupic.bindings.sdr import SDR, Metrics
+import numpy as np
+import argparse
+import matplotlib.pyplot as plt
+
+#
+# Gather input from the user.
+#
+parser = argparse.ArgumentParser(
+    description = "Simple program to examine the ScalarEncoder. /\\/\\/\\ " +
+    ScalarEncoder.__doc__ + ' /\\/\\/\\ ' + ScalarEncoderParameters.__doc__)
+
+parser.add_argument('--activeBits', type=int, default=0,
+                    help=ScalarEncoderParameters.activeBits.__doc__)
+
+parser.add_argument('--minimum', type=float, default=0,
+                    help=ScalarEncoderParameters.minimum.__doc__)
+
+parser.add_argument('--maximum', type=float, default=0,
+                    help=ScalarEncoderParameters.maximum.__doc__)
+
+parser.add_argument('--periodic', action='store_true', default=False,
+                    help=ScalarEncoderParameters.periodic.__doc__)
+
+parser.add_argument('--radius', type=float, default=0,
+                    help=ScalarEncoderParameters.radius.__doc__)
+
+parser.add_argument('--resolution', type=float, default=0,
+                    help=ScalarEncoderParameters.resolution.__doc__)
+
+parser.add_argument('--size', type=int, default=0,
+                    help=ScalarEncoderParameters.size.__doc__)
+
+parser.add_argument('--sparsity', type=float, default=0,
+                    help=ScalarEncoderParameters.sparsity.__doc__)
+
+args = parser.parse_args()
+
+#
+# Setup the encoder.  First copy the command line arguments into the parameter structure.
+#
+parameters = ScalarEncoderParameters()
+parameters.activeBits = args.activeBits
+parameters.clipInput  = False # This script will never encode values outside of the range [min, max]
+parameters.minimum    = args.minimum
+parameters.maximum    = args.maximum
+parameters.periodic   = args.periodic
+parameters.radius     = args.radius
+parameters.resolution = args.resolution
+parameters.size       = args.size
+parameters.sparsity   = args.sparsity
+
+enc = ScalarEncoder( parameters )
+
+#
+# Run the encoder and measure some statistics about its output.
+#
+sdrs = []
+n_samples = (enc.parameters.maximum - enc.parameters.minimum) / enc.parameters.resolution
+n_samples = int(round( 5 * n_samples ))
+for i in np.linspace(enc.parameters.minimum, enc.parameters.maximum, n_samples):
+  sdrs.append( enc.encode( i ) )
+
+M = Metrics( [enc.size], len(sdrs) + 1 )
+for s in sdrs:
+    M.addData(s)
+print("Statistics:")
+print("Encoded %d inputs."%len(sdrs))
+print("Output " + str(M))
+
+#
+# Plot the Receptive Field of each bit in the encoder.
+#
+rf = np.zeros([ enc.size, len(sdrs) ], dtype=np.uint8)
+for i in range(len(sdrs)):
+    rf[ :, i ] = sdrs[i].dense
+plt.imshow(rf, interpolation='nearest')
+plt.title( "ScalarEncoder Receptive Fields")
+plt.ylabel("Cell Number")
+plt.xlabel("Input Value")
+n_ticks = 11
+plt.xticks( np.linspace(0, len(sdrs)-1, n_ticks),
+            np.linspace(enc.parameters.minimum, enc.parameters.maximum, n_ticks))
+plt.show()

--- a/bindings/py/tests/encoders/scalar_encoder_test.py
+++ b/bindings/py/tests/encoders/scalar_encoder_test.py
@@ -40,6 +40,8 @@ class ScalarEncoder_Test(unittest.TestCase):
         p.minimum    = 0
         p.maximum    = 345
         enc = ScalarEncoder( p )
+        assert( enc.dimensions == [1000] )
+        assert( enc.size == 1000 )
         assert( not enc.parameters.clipInput )
         assert( not enc.parameters.periodic )
         assert( abs(enc.parameters.sparsity   - 20./1000) < .01 )

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -116,8 +116,8 @@ namespace encoders {
    * of bits. The output is 0's except for a contiguous block of 1's. The
    * location of this contiguous block varies continuously with the input value.
    *
-   * TODO, Example Usage & unit test for it.
-   *
+   * For help or to examine this run:
+   * $ python -m nupic.examples.rf_view_ScalarEncoder --help.
    */
   class ScalarEncoder : public BaseEncoder<Real64>
   {


### PR DESCRIPTION
This script lets users try out the scalar encoder from the command line.
Some example invocations:
```
$ python3 -m nupic.examples.rf_view_ScalarEncoder --min 0 --max 1 --size 100 --sparsity .10
$ python3 -m nupic.examples.rf_view_ScalarEncoder --min -1 --max 1 --radius .5 --activeBits 20 --periodic
```

This should resolve all outstanding tasks for ScalarEncoder in issue #258.