### PR TITLE
Rename Temporal Memory Bindings file

### DIFF
--- a/bindings/py/cpp_src/CMakeLists.txt
+++ b/bindings/py/cpp_src/CMakeLists.txt
@@ -44,7 +44,7 @@ message(STATUS "Configuring Python interface")
 set(src_py_algorithms_files
     bindings/algorithms/algorithm_module.cpp
     bindings/algorithms/py_Cells4.cpp
-    bindings/algorithms/py_HTM.cpp
+    bindings/algorithms/py_TemporalMemory.cpp
     bindings/algorithms/py_SDRClassifier.cpp
     bindings/algorithms/py_SpatialPooler.cpp
     )

--- a/bindings/py/cpp_src/bindings/algorithms/algorithm_module.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/algorithm_module.cpp
@@ -34,7 +34,7 @@ namespace py = pybind11;
 namespace nupic_ext
 {
     void init_Cells4(py::module&);
-    void init_HTM(py::module&);
+    void init_TemporalMemory(py::module&);
     void init_SDR_Classifier(py::module&);
     void init_Spatial_Pooler(py::module&);
 
@@ -45,7 +45,7 @@ using namespace nupic_ext;
 PYBIND11_MODULE(algorithms, m) {
     m.doc() = "nupic.core.algorithms plugin"; // optional module docstring
 
-    init_HTM(m);
+    init_TemporalMemory(m);
     init_Cells4(m);
     init_SDR_Classifier(m);
     init_Spatial_Pooler(m);

--- a/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
@@ -46,7 +46,7 @@ using namespace nupic;
 using nupic::sdr::SDR;
 using namespace nupic::algorithms::connections; 
 
-    void init_HTM(py::module& m)
+    void init_TemporalMemory(py::module& m)
     {
         typedef nupic::algorithms::temporal_memory::TemporalMemory HTM_t;
 

--- a/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
@@ -54,20 +54,20 @@ using namespace nupic::algorithms::connections;
 
         py_HTM.def(py::init<>());
         py_HTM.def(py::init<std::vector<CellIdx>
-	        , CellIdx
-		, SynapseIdx
-                , Permanence
-		, Permanence
+                , CellIdx
                 , SynapseIdx
-		, SynapseIdx
                 , Permanence
-		, Permanence
-		, Permanence
+                , Permanence
+                , SynapseIdx
+                , SynapseIdx
+                , Permanence
+                , Permanence
+                , Permanence
                 , Int
                 , SegmentIdx
-		, SynapseIdx
+                , SynapseIdx
                 , bool
-		, UInt>()
+                , UInt>()
                 , py::arg("columnDimensions")
                 , py::arg("cellsPerColumn") = 32
                 , py::arg("activationThreshold") = 13


### PR DESCRIPTION
Rename file py_HTM.cpp to py_TemporalMemory.cpp 
Also fixed inconsistent use of tabs/spaces in said file.