### PR TITLE
SDR.randomize python bindings, allow instances of Random

### DIFF
--- a/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
+++ b/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
@@ -234,7 +234,8 @@ I.E.  sparsity = sdr.getSum() / sdr.size)");
         py_SDR.def("randomize",
             [](SDR &self, Real sparsity, UInt seed) {
             Random rng( seed );
-            self.randomize( sparsity, rng ); },
+            self.randomize( sparsity, rng );
+            return self; },
 R"(Make a random SDR, overwriting the current value of the SDR.  The result has
 uniformly random activations.
 
@@ -246,6 +247,16 @@ Optional argument seed is used for the random number generator.  Seed 0 is
 special, it is replaced with the system time  The default seed is 0.)",
             py::arg("sparsity"),
             py::arg("seed") = 0u);
+
+        py::module::import("nupic.bindings.math");
+        py_SDR.def("randomize",
+            [](SDR &self, Real sparsity, Random rng) {
+            self.randomize( sparsity, rng );
+            return self; },
+R"(This overload accepts Random Number Generators (RNG) intead of a random seed.
+RNGs must be instances of "nupic.bindings.math.Random".)",
+                py::arg("sparsity"),
+                py::arg("rng"));
 
         py_SDR.def("addNoise", [](SDR &self, Real fractionNoise, UInt seed = 0) {
             Random rng( seed );

--- a/bindings/py/tests/sdr/SDR_test.py
+++ b/bindings/py/tests/sdr/SDR_test.py
@@ -27,6 +27,7 @@ import pytest
 import time
 
 from nupic.bindings.sdr import SDR, Reshape
+from nupic.bindings.math import Random
 
 class SdrTest(unittest.TestCase):
     def testExampleUsage(self):
@@ -295,6 +296,13 @@ class SdrTest(unittest.TestCase):
         A.randomize( .1, 42 )
         B.randomize( .1, 42 )
         assert( A == B )
+
+    def testRandomRNG(self):
+        x = SDR(1000).randomize(.5, Random(77))
+        y = SDR(1000).randomize(.5, Random(99))
+        assert( x != y )
+        z = SDR(1000).randomize(.5, Random(77))
+        assert( x == z )
 
     def testAddNoise(self):
         A = SDR((103,))


### PR DESCRIPTION
For issue #381.

This also changes SDR.randomize to return itself, whereas previously it returned nothing.
This change makes it possible to call randomize immediately after initializing it:
`X = SDR( dimensions ).randomize( .05 )`