### PR TITLE
RDSE viewing program

### DIFF
--- a/bindings/py/cpp_src/bindings/encoders/py_RDSE.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_RDSE.cpp
@@ -47,21 +47,20 @@ R"(Member "size" is the total number of bits in the encoded output SDR.)");
         py_RDSE_args.def_readwrite("sparsity", &RDSE_Parameters::sparsity,
 R"(Member "sparsity" is the fraction of bits in the encoded output which this
 encoder will activate. This is an alternative way to specify the member
-"activeBits".  Sparsity requires that the size to also be specified.)");
+"activeBits".)");
 
         py_RDSE_args.def_readwrite("activeBits", &RDSE_Parameters::activeBits,
-R"(Member "activeBits" is the number of true bits in the encoded output SDR. The
-output encodings will have a contiguous block of this many 1's.)");
+R"(Member "activeBits" is the number of true bits in the encoded output SDR.)");
 
         py_RDSE_args.def_readwrite("radius", &RDSE_Parameters::radius,
-R"(Member "radius" Two inputs separated by more than the radius have non-
-overlapping representations. Two inputs separated by less than the radius will
-in general overlap in at least some of their bits. You can think of this as the
-radius of the input.)");
+R"(Two inputs separated by more than the radius will have non-overlapping
+representations. Two inputs separated by less than the radius will in general
+overlap in at least some of their bits. You can think of this as the radius of
+the input.)");
 
         py_RDSE_args.def_readwrite("resolution", &RDSE_Parameters::resolution,
-R"(Member "resolution" Two inputs separated by greater than, or equal to the
-resolution are guaranteed to have different representations.)");
+R"(Two inputs separated by greater than, or equal to the resolution are
+guaranteed to have different representations.)");
 
         py_RDSE_args.def_readwrite("seed", &RDSE_Parameters::seed,
 R"(Member "seed" forces different encoders to produce different outputs, even if
@@ -74,7 +73,7 @@ The seed 0 is special.  Seed 0 is replaced with a random number.)");
         py::class_<RDSE> py_RDSE(m, "RDSE",
 R"(Encodes a real number as a set of randomly generated activations.
 
-The RandomDistributedScalarEncoder (RDSE) encodes a numeric scalar (floating
+The Random Distributed Scalar Encoder (RDSE) encodes a numeric scalar (floating
 point) value into an SDR.  The RDSE is more flexible than the ScalarEncoder.
 This encoder does not need to know the minimum and maximum of the input
 range.  It does not assign an input->output mapping at construction.  Instead
@@ -90,7 +89,8 @@ is faster and uses less memory.  It relies on the random & distributed nature
 of SDRs to prevent conflicts between different encodings.  This method does
 not allow for decoding SDRs into the inputs which likely created it.
 
-TODO, Example Usage & unit test for it.)");
+To inspect this run:
+$ python -m nupic.encoders.rdse --help)");
         py_RDSE.def(py::init<RDSE_Parameters>());
 
         py_RDSE.def_property_readonly("parameters",

--- a/bindings/py/tests/encoders/rdse_test.py
+++ b/bindings/py/tests/encoders/rdse_test.py
@@ -22,17 +22,11 @@
 import pickle
 import numpy as np
 import unittest
-import pytest
-import time
 
 from nupic.bindings.sdr import SDR, Metrics
 from nupic.bindings.encoders import RDSE, RDSE_Parameters
 
 class RDSE_Test(unittest.TestCase):
-    @pytest.mark.skip("TODO UNIMPLEMENTED!")
-    def testExampleUsage(self):
-        1/0
-
     def testConstructor(self):
         params1 = RDSE_Parameters()
         params1.size     = 100
@@ -263,6 +257,6 @@ class RDSE_Test(unittest.TestCase):
         B = R.encode( 987654 )
         assert( A != B )
 
-    @pytest.mark.skip(reason="Known issue: https://github.com/htm-community/nupic.cpp/issues/160")
+    @unittest.skip(reason="Known issue: https://github.com/htm-community/nupic.cpp/issues/160")
     def testPickle(self):
         assert(False) # TODO: Unimplemented

--- a/py/src/nupic/encoders/rdse.py
+++ b/py/src/nupic/encoders/rdse.py
@@ -1,0 +1,112 @@
+# ------------------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+#
+# Copyright (C) 2019, David McDougall
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License along with
+# this program.  If not, see http://www.gnu.org/licenses.
+# ------------------------------------------------------------------------------
+
+import nupic.bindings.encoders
+RDSE            = nupic.bindings.encoders.RDSE
+RDSE_Parameters = nupic.bindings.encoders.RDSE_Parameters
+
+__all__ = ['RDSE', 'RDSE_Parameters']
+
+if __name__ == '__main__':
+    """
+    This module is also a program to examine the Random Distributed Scalar
+    Encoder (RDSE).
+
+    For help using this program run:
+    $ python -m nupic.encoders.scalar_encoder --help
+    """
+    import numpy as np
+    from nupic.bindings.sdr import SDR, Metrics
+    import argparse
+    import textwrap
+    import matplotlib.pyplot as plt
+    from sys import exit
+
+    #
+    # Gather input from the user.
+    #
+    parser = argparse.ArgumentParser(
+        formatter_class = argparse.RawDescriptionHelpFormatter,
+        description = "Examine the Random Distributed Scalar Encoder (RDSE).\n\n" +
+                        textwrap.dedent(RDSE.__doc__ + "\n\n" +
+                                        RDSE_Parameters.__doc__))
+    parser.add_argument('--activeBits', type=int, default=0,
+                        help=RDSE_Parameters.activeBits.__doc__)
+    parser.add_argument('--minimum', type=float, required=True,
+                        help="TODO")
+    parser.add_argument('--maximum', type=float, required=True,
+                        help="TODO")
+    parser.add_argument('--radius', type=float, default=0,
+                        help=RDSE_Parameters.radius.__doc__)
+    parser.add_argument('--resolution', type=float, default=0,
+                        help=RDSE_Parameters.resolution.__doc__)
+    parser.add_argument('--size', type=int, required=True,
+                        help=RDSE_Parameters.size.__doc__)
+    parser.add_argument('--sparsity', type=float, default=0,
+                        help=RDSE_Parameters.sparsity.__doc__)
+    args = parser.parse_args()
+
+    #
+    # Setup the encoder.  First copy the command line arguments into the parameter structure.
+    #
+    parameters = RDSE_Parameters()
+    parameters.activeBits = args.activeBits
+    parameters.radius     = args.radius
+    parameters.resolution = args.resolution
+    parameters.size       = args.size
+    parameters.sparsity   = args.sparsity
+
+    # Try initializing the encoder.
+    try:
+        enc = RDSE( parameters )
+    except RuntimeError as error:
+        print("")
+        print(error)
+        print("")
+        parser.print_usage()
+        exit()
+
+    #
+    # Run the encoder and measure some statistics about its output.
+    #
+    sdrs = []
+    n_samples = (args.maximum - args.minimum) / enc.parameters.resolution
+    n_samples = int(round( 5 * n_samples ))
+    for i in np.linspace(args.minimum, args.maximum, n_samples):
+      sdrs.append( enc.encode( i ) )
+
+    M = Metrics( [enc.size], len(sdrs) + 1 )
+    for s in sdrs:
+        M.addData(s)
+    print("Statistics:")
+    print("Encoded %d inputs."%len(sdrs))
+    print("Output " + str(M))
+
+    #
+    # Plot the Receptive Field of each bit in the encoder.
+    #
+    rf = np.zeros([ enc.size, len(sdrs) ], dtype=np.uint8)
+    for i in range(len(sdrs)):
+        rf[ :, i ] = sdrs[i].dense
+    plt.imshow(rf, interpolation='nearest')
+    plt.title( "RDSE Receptive Fields")
+    plt.ylabel("Cell Number")
+    plt.xlabel("Input Value")
+    n_ticks = 11
+    plt.xticks( np.linspace(0, len(sdrs)-1, n_ticks),
+                np.linspace(args.minimum, args.maximum, n_ticks))
+    plt.show()

--- a/src/nupic/encoders/RandomDistributedScalarEncoder.hpp
+++ b/src/nupic/encoders/RandomDistributedScalarEncoder.hpp
@@ -47,14 +47,13 @@ struct RDSE_Parameters
 
   /**
    * Member "activeBits" is the number of true bits in the encoded output SDR.
-   * The output encodings will have a contiguous block of this many 1's.
    */
   UInt activeBits = 0u;
 
   /**
    * Member "sparsity" is the fraction of bits in the encoded output which this
    * encoder will activate. This is an alternative way to specify the member
-   * "activeBits".  Sparsity requires that the size to also be specified.
+   * "activeBits".
    */
   Real sparsity = 0.0f;
 
@@ -102,7 +101,8 @@ struct RDSE_Parameters
  * of SDRs to prevent conflicts between different encodings.  This method does
  * not allow for decoding SDRs into the inputs which likely created it.
  *
- * TODO, Example Usage & unit test for it.
+ * To inspect this run:
+ * $ python -m nupic.encoders.rdse --help
  */
 class RandomDistributedScalarEncoder : public BaseEncoder<Real64>
 {


### PR DESCRIPTION
Last item left to do in PR #278.

Try running: 
`$ python -m nupic.encoders.rdse --help`
Or
`$ python -m nupic.encoders.rdse --min 0 --max 10 --size 100 --active 10 --radius 1`

Also fixed up some documentation errors.

Also imported the RDSE to:
`import nupic.encoders.rdse.RDSE[_Parameters]`