### PR TITLE
Enabling ARM64 CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,9 @@ jobs:
       - setup_remote_docker  # access circleci's custom docker service
       # here we make circleci x86 hardware think it's arm64 via docker+qemu
       - run: $CI_SUDO docker run --rm --privileged multiarch/qemu-user-static:register --reset
-      - run: $CI_SUDO docker build --build-arg arch=arm64 .
+      - run:
+          command: $CI_SUDO docker build --build-arg arch=arm64 .
+          no_output_timeout: 2h
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # CircleCI Build Config
 #   https://circleci.com/docs/2.0/configuration-reference/#section=configuration
 #
-# Targets: 
+# Targets:
 #   - Max OS/X
 #   - ARM64
 
@@ -121,19 +121,23 @@ jobs:
       - image: circleci/buildpack-deps:18.10
     steps:
       - run:
+          # This is for local test builds using the CircleCI terminal app.
+          #   Local Docker seems to use sudo, CircleCI Docker does not.
           command: |
             if [[ $CIRCLE_SHELL_ENV == *"localbuild"* ]]; then
               echo "This is a local build. Enabling sudo for docker"
-              CISUDO=sudo
+              echo 'export CI_SUDO="sudo"' >> $BASH_ENV
             else
-              CISUDO=
+              echo 'export CI_SUDO=' >> $BASH_ENV
             fi
+            source $BASH_ENV
       - run: sudo apt-get -y install qemu-system
       - checkout
       - setup_remote_docker  # access circleci's custom docker service
       # here we make circleci x86 hardware think it's arm64 via docker+qemu
-      - run: $CISUDO docker run --rm --privileged multiarch/qemu-user-static:register --reset
-      - run: $CISUDO docker build --build-arg arch=arm64 .
+      - run: env
+      - run: $CI_SUDO docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      - run: $CI_SUDO docker build --build-arg arch=arm64 .
 
 workflows:
   version: 2
@@ -141,4 +145,3 @@ workflows:
   build-test-deploy:
     jobs:
       - build-and-test
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ version: 2
 jobs:
 
   # job: Mac OS/X raw ("build-and-test")
-  osx-build-and-test:
+  build-and-test:
     macos:
       xcode: '10.1.0'
     working_directory: ~/numenta/nupic.core
@@ -144,6 +144,6 @@ workflows:
   version: 2
   build-test-deploy:
     jobs:
-      - osx-build-and-test    # Mac OS/X raw ("build-and-test")
+      - build-and-test    # Mac OS/X raw ("build-and-test")
       - arm64-build-test  # ARM64 docker/qemu ("arm64-build-test")
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,6 @@ jobs:
       - checkout
       - setup_remote_docker  # access circleci's custom docker service
       # here we make circleci x86 hardware think it's arm64 via docker+qemu
-      - run: env
       - run: $CI_SUDO docker run --rm --privileged multiarch/qemu-user-static:register --reset
       - run: $CI_SUDO docker build --build-arg arch=arm64 .
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,14 @@
+# CircleCI Build Config
+#   https://circleci.com/docs/2.0/configuration-reference/#section=configuration
+#
+# Targets: 
+#   - Max OS/X
+#   - ARM64
+
 version: 2
 jobs:
 
-  # job: Darwin (build-and-test)
+  # job: Mac OS/X raw ("build-and-test")
   build-and-test:
     macos:
       xcode: '10.1.0'
@@ -106,28 +113,31 @@ jobs:
             #tar -zcv -f nupic_core-${CIRCLE_SHA1}-darwin64.tar.gz dist
             #aws s3 cp nupic_core-${CIRCLE_SHA1}-darwin64.tar.gz s3://artifacts.numenta.org/numenta/nupic.core/circle/
 
-  # job: ARM64 (arm64)
-  arm64:
+  # job: ARM64 via Docker + QEMU ("arm64-build-test")
+  arm64-build-test:
     docker:
+      # CircleCI base Ubuntu 18.10 Cosmic with remote Docker access, etc.
+      #   https://circleci.com/docs/2.0/circleci-images/#buildpack-deps
       - image: circleci/buildpack-deps:18.10
     steps:
       - run:
           command: |
             if [[ $CIRCLE_SHELL_ENV == *"localbuild"* ]]; then
               echo "This is a local build. Enabling sudo for docker"
-              echo sudo > ~/sudo
+              CISUDO=sudo
             else
-              echo "This is not a local build. Disabling sudo for docker"
-              touch ~/sudo
+              CISUDO=
             fi
       - run: sudo apt-get -y install qemu-system
       - checkout
-      - setup_remote_docker
-      - run: eval `cat ~/sudo` docker run --rm --privileged multiarch/qemu-user-static:register --reset
-      - run: eval `cat ~/sudo` docker build .
+      - setup_remote_docker  # access circleci's custom docker service
+      # here we make circleci x86 hardware think it's arm64 via docker+qemu
+      - run: $CISUDO docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      - run: $CISUDO docker build --build-arg arch=arm64 .
 
 workflows:
   version: 2
+  # Mac OS/X raw ("build-and-test")
   build-test-deploy:
     jobs:
       - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ version: 2
 jobs:
 
   # job: Mac OS/X raw ("build-and-test")
-  build-and-test:
+  osx-build-and-test:
     macos:
       xcode: '10.1.0'
     working_directory: ~/numenta/nupic.core
@@ -144,6 +144,6 @@ workflows:
   version: 2
   build-test-deploy:
     jobs:
-      - build-and-test    # Mac OS/X raw ("build-and-test")
+      - osx-build-and-test    # Mac OS/X raw ("build-and-test")
       - arm64-build-test  # ARM64 docker/qemu ("arm64-build-test")
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,7 @@
 version: 2
 jobs:
+
+  # job: Darwin (build-and-test)
   build-and-test:
     macos:
       xcode: '10.1.0'
@@ -22,13 +24,12 @@ jobs:
           name: Restoring system python
           command: |
             echo 'python version: ' && python --version
-            echo 'pip version: ' && python -m pip --version 
+            echo 'pip version: ' && python -m pip --version
             echo 'python version: ' && python --version
       - run:
-          name: Installing cmake 
+          name: Installing cmake
           command: brew install cmake || brew install cmake
       - checkout
-
       # Dependencies
       # Restore the dependency cache
       #      - restore_cache:
@@ -37,21 +38,19 @@ jobs:
       #    - v1-dep-{{ .Branch }}-
       #    # Default branch if not
       #    - v1-dep-master-
-      #    # Any branch if there are none on the default branch - this should be 
+      #    # Any branch if there are none on the default branch - this should be
       #    # unnecessary if you have your default branch configured correctly
       #    - v1-dep-
-
       - run:
            name: Installing python dependencies
            command: |
                    python -m pip install --user --upgrade pip setuptools setuptools-scm
                    python -m pip install --no-cache-dir --user -r bindings/py/packaging/requirements.txt  --verbose || exit
-
       # Save dependency cache
       #      - save_cache:
       #    key: v1-dep-{{ .Branch }}-{{ epoch }}
       #    paths:
-      #    # This is a broad list of cache paths to include many possible 
+      #    # This is a broad list of cache paths to include many possible
       #    # development environments.
       #    - vendor/bundle
       #    - ~/virtualenvs
@@ -61,8 +60,7 @@ jobs:
       #    - ~/.go_workspace
       #    - ~/.gradle
       #    - ~/.cache/bower
-
-      # Build 
+      # Build
       - run:
           name: Compiling
           environment:
@@ -70,14 +68,12 @@ jobs:
           command: |
             mkdir -p build/scripts
             cd build/scripts
-            cmake ../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../Release 
+            cmake ../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../Release
             make | grep -v -F '\\-\\- Installing:'
             make install 2>&1 | grep -v -F 'Installing:'
-       
       - run:
            name: Install Python extension
            command: python setup.py install --user --prefix=
-
       # Test
       - run:
           name: Running C++ Tests
@@ -88,21 +84,16 @@ jobs:
       - run:
           name: Running python tests
           command: python setup.py test
-
-
       - store_test_results:
           path: tests
-    
       - store_artifacts:
           path: dist/*.whl
-        
       ##- persist_to_workspace:
       ##    root: dist
       ##    paths:
       ##    - nupic.bindings*.whl
       ##    - requirements.txt
       ##    - include/nupic
-
             #  deploy-s3:
             #machine: true
             #steps:
@@ -115,8 +106,29 @@ jobs:
             #tar -zcv -f nupic_core-${CIRCLE_SHA1}-darwin64.tar.gz dist
             #aws s3 cp nupic_core-${CIRCLE_SHA1}-darwin64.tar.gz s3://artifacts.numenta.org/numenta/nupic.core/circle/
 
+  # job: ARM64 (arm64)
+  arm64:
+    docker:
+      - image: circleci/buildpack-deps:18.10
+    steps:
+      - run:
+          command: |
+            if [[ $CIRCLE_SHELL_ENV == *"localbuild"* ]]; then
+              echo "This is a local build. Enabling sudo for docker"
+              echo sudo > ~/sudo
+            else
+              echo "This is not a local build. Disabling sudo for docker"
+              touch ~/sudo
+            fi
+      - run: sudo apt-get -y install qemu-system
+      - checkout
+      - setup_remote_docker
+      - run: eval `cat ~/sudo` docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      - run: eval `cat ~/sudo` docker build .
+
 workflows:
   version: 2
   build-test-deploy:
     jobs:
       - build-and-test
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,8 @@ jobs:
 
 workflows:
   version: 2
-  # Mac OS/X raw ("build-and-test")
   build-test-deploy:
     jobs:
-      - build-and-test
+      - build-and-test    # Mac OS/X raw ("build-and-test")
+      - arm64-build-test  # ARM64 docker/qemu ("arm64-build-test")
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Default arch. Pass in with "--build-arg arch=arm64", etc.
+# Default arch. Pass in like "--build-arg arch=arm64".
 #   Our circleci arm64 build uses this specifically.
 #   https://docs.docker.com/engine/reference/commandline/build/
 ARG arch=x86_64

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ARG arch=x86_64
 #   https://hub.docker.com/r/multiarch/ubuntu-core/tags/
 FROM multiarch/ubuntu-core:$arch-bionic
 
-RUN apt-get install -y \
+RUN apt-get update && \
+    apt-get install -y \
     curl \
     wget \
     git-core \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,10 @@ RUN apt-get update && \
     curl \
     wget \
     git-core \
+    gcc \
     g++ \
     cmake \
+    python \
     python2.7 \
     python2.7-dev \
     zlib1g-dev \
@@ -24,6 +26,7 @@ RUN wget http://releases.numenta.org/pip/1ebd3cb7a5a3073058d0c9552ab074bd/get-pi
 RUN pip install --upgrade setuptools
 RUN pip install wheel
 
+ENV CC gcc
 ENV CXX g++
 
 ADD . /usr/local/src/nupic.cpp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
-#FROM ubuntu:18.04
-FROM multiarch/ubuntu-core:arm64-bionic
+# Default arch. Pass in with "--build-arg arch=arm64", etc.
+#   Our circleci arm64 build uses this specifically.
+#   https://docs.docker.com/engine/reference/commandline/build/
+ARG arch=x86_64
+
+# Multiarch Ubuntu Bionic 18.04. arches: x86_64, arm64, etc.
+#   https://hub.docker.com/r/multiarch/ubuntu-core/tags/
+FROM multiarch/ubuntu-core:$arch-bionic
+
 RUN apt-get update && \
     apt-get install -y \
     curl \
@@ -23,17 +30,14 @@ ENV CC gcc
 ENV CXX g++
 
 ADD . /usr/local/src/nupic.cpp
-
 WORKDIR /usr/local/src/nupic.cpp
 
 # Explicitly specify --cache-dir, --build, and --no-clean so that build
 # artifacts may be extracted from the container later.  Final built python
 # packages can be found in /usr/local/src/nupic.cpp/bindings/py/dist
-
 RUN pip install \
         --cache-dir /usr/local/src/nupic.cpp/pip-cache \
         --build /usr/local/src/nupic.cpp/pip-build \
         --no-clean \
         -r bindings/py/packaging/requirements.txt && \
     python setup.py bdist bdist_dumb bdist_wheel sdist
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,8 @@ RUN apt-get install -y \
     curl \
     wget \
     git-core \
-    gcc \
     g++ \
     cmake \
-    python \
     python2.7 \
     python2.7-dev \
     zlib1g-dev \
@@ -25,7 +23,6 @@ RUN wget http://releases.numenta.org/pip/1ebd3cb7a5a3073058d0c9552ab074bd/get-pi
 RUN pip install --upgrade setuptools
 RUN pip install wheel
 
-ENV CC gcc
 ENV CXX g++
 
 ADD . /usr/local/src/nupic.cpp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:14.04
-
+#FROM ubuntu:18.04
+FROM multiarch/ubuntu-core:arm64-bionic
 RUN apt-get update && \
     apt-get install -y \
     curl \
@@ -22,17 +22,18 @@ RUN pip install wheel
 ENV CC gcc
 ENV CXX g++
 
-ADD . /usr/local/src/nupic.core
+ADD . /usr/local/src/nupic.cpp
 
-WORKDIR /usr/local/src/nupic.core
+WORKDIR /usr/local/src/nupic.cpp
 
 # Explicitly specify --cache-dir, --build, and --no-clean so that build
 # artifacts may be extracted from the container later.  Final built python
-# packages can be found in /usr/local/src/nupic.core/bindings/py/dist
+# packages can be found in /usr/local/src/nupic.cpp/bindings/py/dist
 
 RUN pip install \
-        --cache-dir /usr/local/src/nupic.core/pip-cache \
-        --build /usr/local/src/nupic.core/pip-build \
+        --cache-dir /usr/local/src/nupic.cpp/pip-cache \
+        --build /usr/local/src/nupic.cpp/pip-build \
         --no-clean \
-        -r bindings/py/requirements.txt && \
+        -r bindings/py/packaging/requirements.txt && \
     python setup.py bdist bdist_dumb bdist_wheel sdist
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ ARG arch=x86_64
 #   https://hub.docker.com/r/multiarch/ubuntu-core/tags/
 FROM multiarch/ubuntu-core:$arch-bionic
 
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt-get install -y \
     curl \
     wget \
     git-core \

--- a/README.md
+++ b/README.md
@@ -197,29 +197,20 @@ docker build --build-arg arch=arm64 .
 
  * [Build](https://circleci.com/gh/htm-community/nupic.cpp/tree/master)
  * [Config](./.circleci/config.yml)
-
-**Local Test Build:**
-```sh
-# brew install circleci
-circleci local execute --job build-and-test
-```
+ * Local Test Build: `circleci local execute --job build-and-test`
 
 #### Windows auto build @ AppVeyor
+
  * [Build](https://ci.appveyor.com/project/htm-community/nupic-cpp/branch/master)
  * [Config](./appveyor.yml)
 
 #### ARM64 auto build @ CircleCI
 
- * **TODO!** [Build]()
- * [Config](./.circleci/config.yml)
-
 This uses Docker and QEMU to achieve an ARM64 build on CircleCI's x86 hardware.
 
-**Local Test Build:**
-```sh
-# brew install circleci
-circleci local execute --job arm64-build-test
-```
+ * **TODO!** [Build]()
+ * [Config](./.circleci/config.yml)
+ * Local Test Build: `circleci local execute --job arm64-build-test`
 
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 <img src="http://numenta.org/87b23beb8a4b7dea7d88099bfb28d182.svg" alt="NuPIC Logo" width=100/>
 
 # NuPIC C++ Core Library
-[![Linux/OSX Build Status](https://travis-ci.org/htm-community/nupic.cpp.svg?branch=master)](https://travis-ci.org/htm-community/nupic.cpp)  
-[![OSX CircleCI](https://circleci.com/gh/htm-community/nupic.cpp/tree/master.svg?style=svg)](https://circleci.com/gh/htm-community/nupic.cpp/tree/master) 
+
+[![Linux/OSX Build Status](https://travis-ci.org/htm-community/nupic.cpp.svg?branch=master)](https://travis-ci.org/htm-community/nupic.cpp)
+[![OSX CircleCI](https://circleci.com/gh/htm-community/nupic.cpp/tree/master.svg?style=svg)](https://circleci.com/gh/htm-community/nupic.cpp/tree/master)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/59f87and1x0ugss9/branch/master?svg=true)](https://ci.appveyor.com/project/htm-community/nupic-cpp/branch/master)
+
 
 ## Community NuPIC.cpp (former nupic.core) repository
 
-This fork is a community version of the [nupic.core](https://github.com/numenta/nupic.core) C++ repository with Python bindings. 
-Our aim is to provide an actively developed successor to the nupic.core and nupic repositories by Numenta, 
-which are not actively developed anymore. 
-
+This fork is a community version of the [nupic.core](https://github.com/numenta/nupic.core) C++ repository with Python bindings.
+Our aim is to provide an actively developed successor to the nupic.core and nupic repositories by Numenta,
+which are not actively developed anymore.
 
 ### Our goals
 
@@ -25,28 +26,28 @@ which are not actively developed anymore.
   - Currently only python has bindings, located in `bindings/py`
 
 
-This repository contains the C++ source code for the Numenta Platform for 
-Intelligent Computing ([NuPIC](http://numenta.org/nupic.html)). 
-It will eventually contain all algorithms for NuPIC, but is currently in a transition period. 
+This repository contains the C++ source code for the Numenta Platform for
+Intelligent Computing ([NuPIC](http://numenta.org/nupic.html)).
+It will eventually contain all algorithms for NuPIC, but is currently in a transition period.
 
-\*) Nupic API compatability: The objective is to stay as close as possible to the [Nupic API Docs](http://nupic.docs.numenta.org/stable/api/index.html) 
-with the aim that we don't break `.py` code written against the numenta's nupic.core extension library if they were to be 
+\*) Nupic API compatability: The objective is to stay as close as possible to the [Nupic API Docs](http://nupic.docs.numenta.org/stable/api/index.html)
+with the aim that we don't break `.py` code written against the numenta's nupic.core extension library if they were to be
 ran against this extention library. If you are porting your code to this codebase, please review [API Changelog](API_CHANGELOG.md).
 
-### New Features 
+### New Features
 
 Some of the major differences between this library and Numenta's extension library are the following:
 
  * Support for Python 3 and Python 2.7 (Only Python 3 under windows)
  * Support for Linux, OSx, and Windows MS Visual Studio 2017
- * Support for C++11 through C++17 
+ * Support for C++11 through C++17
  * Replaced SWIG with PyBind11 for Python interface.
- * Removed CapnProto serialization.  It was prevasive and complicated the code considerably. It was replaced 
+ * Removed CapnProto serialization.  It was prevasive and complicated the code considerably. It was replaced
  with simple binary streaming serialization in C++ library.
- * Many code optimizations, modernization (Spatial Pooler shares optimized Connections backend with Temporal memory) 
+ * Many code optimizations, modernization (Spatial Pooler shares optimized Connections backend with Temporal memory)
  * Modular structure
  * Interfaces & API stabilization, making it easier for developers & researchers to use our codebase
- * Much easier installation (reduced dependencies, all are handeled by CMake) 
+ * Much easier installation (reduced dependencies, all are handeled by CMake)
  * Static and shared lib files for use with C++ applications.
  * New and Improved Algorithms:
    - Sparse Distributed Representations
@@ -54,7 +55,7 @@ Some of the major differences between this library and Numenta's extension libra
    - Backtracking Temporal Memory
    - Significantly faster Spatial Pooler and Connections
 
-## Installation 
+## Installation
 
 ### Prerequisites
 
@@ -63,9 +64,9 @@ Some of the major differences between this library and Numenta's extension libra
     - Version 2.7  We recommend you use the latest 2.7 version where possible. But the system version should be fine. (The extension library for Python 2.7 not supported on Windows.)
     - Version 3.4+  The Nupic Python repository will need to be upgraded as well before this will be useful.
   Be sure that your Python executable is in the Path environment variable. The Python that is in your default path is the one
-  that will determine which version of Python the extension library will be built for.  
-  NOTE: Anaconda Python not supported. 
-  Other implementations of Python may not work. 
+  that will determine which version of Python the extension library will be built for.
+  NOTE: Anaconda Python not supported.
+  Other implementations of Python may not work.
   Only the standard python from python.org have been tested.
 - Python tools: In a command prompt execute the following.
 ```
@@ -85,7 +86,7 @@ Fork or download the HTM-Community Nupic.cpp repository from https://github.com/
 
 #### Simple Build for Python users (any platform)
 
-The easiest way to build from source is as follows. 
+The easiest way to build from source is as follows.
 ```
     cd to-repository-root
     python setup.py install --user --force
@@ -104,7 +105,7 @@ After that completes you are all set to run your .py programs which import the e
  * nupic.bindings.math
  * nupic.bindings.encoders
  * nupic.bindings.sdr
- 
+
 The installation scripts will automatically download and build the dependancies it needs.
  * Boost   (Not needed by C++17 compilers that support the filesystem module)
  * Yaml-cpp
@@ -112,15 +113,15 @@ The installation scripts will automatically download and build the dependancies 
  * PyBind11
  * gtest
  * cereal
- * mnist test data 
+ * mnist test data
  * numpy
  * pytest
- 
- If you are installing on an air-gap computer (one without internet) then you can 
+
+ If you are installing on an air-gap computer (one without internet) then you can
  manually download the dependancies.  On another computer, download the distribution
  packages as listed and rename them as indicated. Copy these to
   `${REPOSITORY_DIR}/build/ThirdParty/share` on the target machine.
-  
+
  | Name to give it | Where to obtain it |
  | :-------------- | :----------------- |
  | yaml-cpp.zip  *note1 | https://github.com/jbeder/yaml-cpp/archive/master.zip |
@@ -130,13 +131,13 @@ The installation scripts will automatically download and build the dependancies 
  | mnist.zip     *note3 | https://github.com/wichtounet/mnist/archive/master.zip |
  | pybind11.tar.gz      | https://github.com/pybind/pybind11/archive/v2.2.4.tar.gz |
  | cereal.tar.gz        | https://github.com/USCiLab/cereal/archive/v1.2.2.tar.gz |
- 
+
  *note1: Version 0.6.2 of yaml-cpp is broken so use the master from the repository.
  *note2: Boost is not required for Windows (MSVC 2017) or any compiler that supports C++17 with std::filesystem.
  *note3: Data used for demo. Not required.
- 
+
 #### Simple Build On Linux or OSX for C++ apps
- 
+
 After downloading the repository, do the following:
 ```
 	cd path-to-repository
@@ -144,16 +145,16 @@ After downloading the repository, do the following:
 	cd build/scripts
 	cmake ../..
 	make install
-```	
-This will build the Nupic.core library without the Python interface. 
+```
+This will build the Nupic.core library without the Python interface.
  * build/Release/lib/libnupic-core.a   static library
  * build/Release/lib/libnupic-core.so  shared library
  * The headers will be in `build/Release/include`.
 
-A debug library can be created by adding `-DCMAKE_BUILD_TYPE=Debug` to the cmake command above.  The -j3 could be used 
+A debug library can be created by adding `-DCMAKE_BUILD_TYPE=Debug` to the cmake command above.  The -j3 could be used
 with the `make install` command to compile with multiple threads.
 
-#### Simple Build On Windows (MS Visual Studio 2017) 
+#### Simple Build On Windows (MS Visual Studio 2017)
 
 After downloading the repository, do the following:
  * CD to top of repository.
@@ -164,6 +165,63 @@ After downloading the repository, do the following:
  * In the solution explorer window, right Click on 'unit_tests' and select `Set as StartUp Project` so debugger will run unit tests.
  * If you also want the Python extension library; in a command prompt, cd to root of repository and run `python setup.py install --user --prefix=`.
 
+
+### Docker Builds
+
+#### Build for Docker x86_64
+
+If you are on `x86_64` and would like to build a Docker image:
+
+```sh
+docker build --build-arg arch=x86_64 .
+```
+
+#### Docker build for ARM64
+
+If you are on `ARM64` and would like to build a Docker image, run the command
+below. The CircleCI automated ARM64 build (detailed below) uses this
+specifically.
+
+```sh
+docker build --build-arg arch=arm64 .
+```
+
+### Automated Builds
+
+#### Linux auto build @ TravisCI
+
+ * [Build](https://travis-ci.org/htm-community/nupic.cpp)
+ * [Config](./.travis.yml)
+
+#### Mac OS/X auto build @ CircleCI
+
+ * [Build](https://circleci.com/gh/htm-community/nupic.cpp/tree/master)
+ * [Config](./.circleci/config.yml)
+
+**Local Test Build:**
+```sh
+# brew install circleci
+circleci local execute --job build-and-test
+```
+
+#### Windows auto build @ AppVeyor
+ * [Build](https://ci.appveyor.com/project/htm-community/nupic-cpp/branch/master)
+ * [Config](./appveyor.yml)
+
+#### ARM64 auto build @ CircleCI
+
+ * **TODO!** [Build]()
+ * [Config](./.circleci/config.yml)
+
+This uses Docker and QEMU to achieve an ARM64 build on CircleCI's x86 hardware.
+
+**Local Test Build:**
+```sh
+# brew install circleci
+circleci local execute --job arm64-build-test
+```
+
+
 ### Testing
 
 #### Unit tests for the library
@@ -171,7 +229,7 @@ After downloading the repository, do the following:
 There are two sets of unit tests.
  * C++ Unit tests -- to run: `cd build/Release/bin; ./unit_tests`
  * Python Unit tests -- to run: `python setup.py test`
- 
+
 ### Using graphical interface
 
 #### Generate the IDE solution  (Netbeans, XCode, Eclipse, KDevelop, etc)
@@ -181,7 +239,7 @@ There are two sets of unit tests.
  * Specify the source folder (`$NUPIC_CORE`) which is the location of the root CMakeList.exe.
  * Specify the build system folder (`$NUPIC_CORE/build/scripts`), i.e. where IDE solution will be created.
  * Click `Generate`.
- 
+
 #### For MS Visual Studio 2017 as the IDE
  * Double click startupMSVC.bat  -- This will setup the build and create the solution file (.sln).
  * Double click build/scripts/nupic.cpp.sln -- This starts up Visual Studio


### PR DESCRIPTION
## Enabling ARM64 CI

Enabling ARM64 CI on CircleCI using Docker + QEMU.

### TODO

  * [x] ~workflow config too? researching.~
  * [x] ~can we mark a job/platform(this arm64) in circle to "be able to fail"? (per @breznak)~
  * [ ] Add final badge and supported text to top of README
  * [ ] Build will be failing until https://github.com/htm-community/nupic.cpp/issues/131 is resolved

### Changes

* Added docs (inline and readme) for the changes below.
* Moved CircleCI config from old 1.x location to new 2.x location.
  * Added CircleCI config for ARM64 Docker+QEMU build.
* Updated Dockerfile
  * Migrated from nupic.core to nupic.cpp
  * Add support from command-line argument variable pass-in (arch)
  * Modernize and prep to work for both Linux x86_64 and ARM64
* Aligned badges on top of README
* Removed some ugly blank lines and my editor removed some orphan spaces.

### Local Test

```sh
# developing on mac os/x
brew install circleci
cd nupic.cpp/
circleci local execute --job arm64-build-test
```

### Context

* https://github.com/htm-community/nupic.cpp/issues/134
* https://github.com/brev/nupic.cpp/pull/1
