### PR TITLE
TemporalMemory python bindings improvements

### DIFF
--- a/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
@@ -135,11 +135,18 @@ using namespace nupic::algorithms::connections;
                                  const SDR &extraActive, const SDR &extraWinners)
             { self.compute(activeColumns, learn, extraActive, extraWinners); });
 
+        py_HTM.def("reset", &HTM_t::reset);
+
         py_HTM.def("getActiveCells", [](const HTM_t& self)
         {
             auto activeCells = self.getActiveCells();
 
             return py::array_t<nupic::UInt32>(activeCells.size(), activeCells.data());
+        });
+
+        py_HTM.def("activateDendrites", [](HTM_t &self, bool learn) {
+            SDR extra({ self.extra });
+            self.activateDendrites(learn, extra, extra);
         });
 
         py_HTM.def("getPredictiveCells", [](const HTM_t& self)
@@ -183,6 +190,14 @@ using namespace nupic::algorithms::connections;
         {
             self.compute(activeColumns.size(), get_it(activeColumns), learn);
         }, "", py::arg("activeColumns"), py::arg("learn") = true);
+
+        py_HTM.def("createSegment", &HTM_t::createSegment);
+
+        py_HTM.def("numberOfCells",   &HTM_t::numberOfCells);
+
+        py_HTM.def("numberOfColumns", &HTM_t::numberOfColumns);
+
+        py_HTM.def_property_readonly("extra", [](const HTM_t &self) { return self.extra; } );
 
     }
 

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -631,6 +631,7 @@ protected:
 
 public:
   Connections connections; //TODO not public!
+  const UInt &extra = extra_;
 };
 
 } // end namespace temporal_memory


### PR DESCRIPTION
For issue #289.

Add python methods
- TM.reset()
- TM.activateDendrites()
- TM.numberOfCells()
- TM.numberOfColumns()
- TM.createSegment()