### PR TITLE
Connections pybind & analysis

### DIFF
--- a/bindings/py/cpp_src/CMakeLists.txt
+++ b/bindings/py/cpp_src/CMakeLists.txt
@@ -43,6 +43,7 @@ message(STATUS "Configuring Python interface")
 #
 set(src_py_algorithms_files
     bindings/algorithms/algorithm_module.cpp
+    bindings/algorithms/py_Connections.cpp
     bindings/algorithms/py_TemporalMemory.cpp
     bindings/algorithms/py_SDRClassifier.cpp
     bindings/algorithms/py_SpatialPooler.cpp

--- a/bindings/py/cpp_src/bindings/algorithms/algorithm_module.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/algorithm_module.cpp
@@ -33,6 +33,7 @@ namespace py = pybind11;
 
 namespace nupic_ext
 {
+    void init_Connections(py::module&);
     void init_TemporalMemory(py::module&);
     void init_SDR_Classifier(py::module&);
     void init_Spatial_Pooler(py::module&);
@@ -44,6 +45,7 @@ using namespace nupic_ext;
 PYBIND11_MODULE(algorithms, m) {
     m.doc() = "nupic.core.algorithms plugin"; // optional module docstring
 
+    init_Connections(m);
     init_TemporalMemory(m);
     init_SDR_Classifier(m);
     init_Spatial_Pooler(m);

--- a/bindings/py/cpp_src/bindings/algorithms/py_Connections.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_Connections.cpp
@@ -45,6 +45,9 @@ namespace nupic_ext
         py::arg("connectedThreshold"),
         py::arg("timeseries") = false);
 
+    py_Connections.def_property_readonly("connectedThreshold",
+        [](const Connections &self) { return self.getConnectedThreshold(); });
+
     py_Connections.def("createSegment", &Connections::createSegment,
         py::arg("cell"));
 
@@ -133,6 +136,19 @@ namespace nupic_ext
             C->load( buf );
             return C;
         } ));
+
+    py_Connections.def("save",
+        [](const Connections &self) {
+            std::stringstream buf;
+            self.save( buf );
+            return py::bytes( buf.str() ); });
+
+    py_Connections.def("load",
+        [](const py::bytes &data) {
+            std::stringstream buf( data.cast<std::string>() );
+            auto C = new Connections();
+            C->load( buf );
+            return C; } );
 
   } // End function init_Connections
 }   // End namespace nupic_ext

--- a/bindings/py/cpp_src/bindings/algorithms/py_Connections.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_Connections.cpp
@@ -94,8 +94,52 @@ R"(Compatibility Warning: This classes API is unstable and may change without wa
 
     py_Connections.def("reset", &Connections::reset);
 
-    // TODO: computeActivity
-    // TODO: computeActivity
+    py_Connections.def("computeActivity",
+        [](Connections &self, SDR &activePresynapticCells) {
+            // Allocate buffer to return & make a python destructor object for it.
+            auto activeConnectedSynapses =
+                new std::vector<SynapseIdx>( self.segmentFlatListLength(), 0u );
+            auto destructor = py::capsule( activeConnectedSynapses,
+                [](void *dataPtr) {
+                    delete reinterpret_cast<std::vector<SynapseIdx>*>(dataPtr); });
+            // Call the C++ method.
+            self.computeActivity(*activeConnectedSynapses, activePresynapticCells.getSparse());
+            // Wrap vector in numpy array.
+            return py::array(activeConnectedSynapses->size(),
+                             activeConnectedSynapses->data(),
+                             destructor);
+        },
+R"(Returns numActiveConnectedSynapsesForSegment)");
+
+    py_Connections.def("computeActivityFull",
+        [](Connections &self, SDR &activePresynapticCells) {
+            // Allocate buffer to return & make a python destructor object for it.
+            auto activeConnectedSynapses =
+                new std::vector<SynapseIdx>( self.segmentFlatListLength(), 0u );
+            auto connectedDestructor = py::capsule( activeConnectedSynapses,
+                [](void *dataPtr) {
+                    delete reinterpret_cast<std::vector<SynapseIdx>*>(dataPtr); });
+            // Allocate buffer to return & make a python destructor object for it.
+            auto activePotentialSynapses =
+                new std::vector<SynapseIdx>( self.segmentFlatListLength(), 0u );
+            auto potentialDestructor = py::capsule( activePotentialSynapses,
+                [](void *dataPtr) {
+                    delete reinterpret_cast<std::vector<SynapseIdx>*>(dataPtr); });
+            // Call the C++ method.
+            self.computeActivity(*activeConnectedSynapses, *activePotentialSynapses,
+                                            activePresynapticCells.getSparse());
+            // Wrap vector in numpy array.
+            return py::make_tuple(
+                    py::array(activeConnectedSynapses->size(),
+                              activeConnectedSynapses->data(),
+                              connectedDestructor),
+                    py::array(activePotentialSynapses->size(),
+                              activePotentialSynapses->data(),
+                              potentialDestructor));
+        },
+R"(Returns pair of:
+    numActiveConnectedSynapsesForSegment
+    numActivePotentialSynapsesForSegment)");
 
     py_Connections.def("adaptSegment", &Connections::adaptSegment);
 

--- a/bindings/py/cpp_src/bindings/algorithms/py_Connections.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_Connections.cpp
@@ -39,7 +39,9 @@ namespace nupic_ext
 {
   void init_Connections(py::module& m)
   {
-    py::class_<Connections> py_Connections(m, "Connections");
+    py::class_<Connections> py_Connections(m, "Connections",
+R"(Compatibility Warning: This classes API is unstable and may change without warning.)");
+
     py_Connections.def(py::init<UInt, Permanence, bool>(),
         py::arg("numCells"),
         py::arg("connectedThreshold"),

--- a/bindings/py/cpp_src/bindings/algorithms/py_Connections.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_Connections.cpp
@@ -1,0 +1,138 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2019, David McDougall
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ * --------------------------------------------------------------------- */
+
+/** @file
+ * PyBind11 bindings for Connections class
+ */
+
+#include <bindings/suppress_register.hpp>  //include before pybind11.h
+#include <pybind11/pybind11.h>
+#include <pybind11/iostream.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+
+#include <string>
+#include <sstream>
+
+#include <nupic/algorithms/Connections.hpp>
+
+namespace py = pybind11;
+using namespace nupic;
+using namespace nupic::algorithms::connections;
+using nupic::sdr::SDR;
+
+namespace nupic_ext
+{
+  void init_Connections(py::module& m)
+  {
+    py::class_<Connections> py_Connections(m, "Connections");
+    py_Connections.def(py::init<UInt, Permanence, bool>(),
+        py::arg("numCells"),
+        py::arg("connectedThreshold"),
+        py::arg("timeseries") = false);
+
+    py_Connections.def("createSegment", &Connections::createSegment,
+        py::arg("cell"));
+
+    py_Connections.def("destroySegment", &Connections::destroySegment);
+
+    py_Connections.def("createSynapse", &Connections::createSynapse,
+        py::arg("segment"),
+        py::arg("presynaticCell"),
+        py::arg("permanence"));
+
+    py_Connections.def("destroySynapse", &Connections::destroySynapse);
+
+    py_Connections.def("updateSynapsePermanence", &Connections::updateSynapsePermanence,
+        py::arg("synapse"),
+        py::arg("permanence"));
+
+    py_Connections.def("segmentsForCell", &Connections::segmentsForCell);
+
+    py_Connections.def("synapsesForSegment", &Connections::synapsesForSegment);
+
+    py_Connections.def("cellForSegment", &Connections::cellForSegment);
+
+    py_Connections.def("idxOnCellForSegment", &Connections::idxOnCellForSegment);
+
+    py_Connections.def("segmentForSynapse", &Connections::segmentForSynapse);
+
+    py_Connections.def("permanenceForSynapse",
+        [](Connections &self, Synapse idx) {
+            auto &synData = self.dataForSynapse( idx );
+            return synData.permanence; });
+
+    py_Connections.def("presynapticCellForSynapse",
+        [](Connections &self, Synapse idx) {
+            auto &synData = self.dataForSynapse( idx );
+            return synData.presynapticCell; });
+
+    py_Connections.def("getSegment", &Connections::getSegment);
+
+    py_Connections.def("segmentFlatListLength", &Connections::segmentFlatListLength);
+
+    py_Connections.def("synapsesForPresynapticCell", &Connections::synapsesForPresynapticCell);
+
+    py_Connections.def("reset", &Connections::reset);
+
+    // TODO: computeActivity
+    // TODO: computeActivity
+
+    py_Connections.def("adaptSegment", &Connections::adaptSegment);
+
+    py_Connections.def("raisePermanencesToThreshold", &Connections::raisePermanencesToThreshold);
+
+    py_Connections.def("bumpSegment", &Connections::bumpSegment);
+
+    py_Connections.def("numCells", &Connections::numCells);
+
+    py_Connections.def("numSegments",
+        [](Connections &self) { return self.numSegments(); });
+    py_Connections.def("numSegments",
+        [](Connections &self, CellIdx cell) { return self.numSegments(cell); });
+
+    py_Connections.def("numSynapses",
+        [](Connections &self) { return self.numSynapses(); });
+    py_Connections.def("numSynapses",
+        [](Connections &self, Segment seg) { return self.numSynapses(seg); });
+
+    py_Connections.def("numConnectedSynapses",
+        [](Connections &self, Segment seg) {
+            auto &segData = self.dataForSegment( seg );
+            return segData.numConnected; });
+
+    py_Connections.def("__str__",
+        [](Connections &self) {
+            std::stringstream buf;
+            buf << self;
+            return buf.str(); });
+
+    py_Connections.def(py::pickle(
+        [](const Connections &self) {   // Save
+            std::stringstream buf;
+            self.save( buf );
+            return py::bytes( buf.str() );
+        },
+        [](const py::bytes &data) {     // Load
+            std::stringstream buf( data.cast<std::string>() );
+            auto C = new Connections();
+            C->load( buf );
+            return C;
+        } ));
+
+  } // End function init_Connections
+}   // End namespace nupic_ext

--- a/py/src/nupic/examples/connections_analysis.py
+++ b/py/src/nupic/examples/connections_analysis.py
@@ -1,0 +1,109 @@
+# ------------------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+#
+# Copyright (C) 2019, David McDougall
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero Public License version 3 as published by the Free
+# Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License along with
+# this program.  If not, see http://www.gnu.org/licenses.
+# ------------------------------------------------------------------------------
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from nupic.bindings.algorithms import Connections
+
+
+def segmentsPerCell(connections, show=True):
+    # Histogram of segments per cell
+    data = []
+    for cell in range( connections.numCells() ):
+        datum = len( connections.segmentsForCell(cell) )
+        data.append(datum)
+    plt.figure("Histogram of Segments per Cell")
+    plt.hist( data )
+    plt.title("Histogram of Segments per Cell")
+    plt.ylabel("Number of Cells")
+    plt.xlabel("Number of Segments")
+    if show:
+        plt.show()
+
+
+def potentialSynapsesPerSegment(connections, show=True):
+    # Histogram of synapses per segment
+    data = []
+    for cell in range( connections.numCells() ):
+        for seg in connections.segmentsForCell(cell):
+            datum = len( connections.synapsesForSegment(seg) )
+            data.append(datum)
+    plt.figure("Histogram of Potential Synapses per Segment")
+    plt.hist( data, bins = 50 )
+    plt.title("Histogram of Potential Synapses per Segment")
+    plt.ylabel("Number of Segments")
+    plt.xlabel("Number of Potential Synapses")
+    if show:
+        plt.show()
+
+
+def connectedSynapsesPerSegment(connections, show=True):
+    # Histogram of synapses per segment
+    data = []
+    for cell in range( connections.numCells() ):
+        for seg in connections.segmentsForCell(cell):
+            datum = connections.numConnectedSynapses(seg)
+            data.append(datum)
+    plt.figure("Histogram of Connected Synapses per Segment")
+    plt.hist( data, bins = 50 )
+    plt.title("Histogram of Connected Synapses per Segment")
+    plt.ylabel("Number of Segments")
+    plt.xlabel("Number of Connected Synapses")
+    if show:
+        plt.show()
+
+
+def permanences(connections, show=True):
+    # Histogram of synapse permanences
+    # Draw vertical line at the connected synapse permanece threshold
+    data = []
+    for cell in range( connections.numCells() ):
+        for seg in connections.segmentsForCell(cell):
+            for syn in connections.synapsesForSegment(seg):
+                datum = connections.permanenceForSynapse(syn)
+                data.append(datum)
+    plt.figure("Histogram of Synapse Permanences")
+    plt.hist( data, bins = 100, range = (0, 1) )
+    plt.axvline( connections.connectedThreshold, color='red' )
+    plt.title("Histogram of Synapse Permanences")
+    plt.ylabel("Number of Synapses")
+    plt.xlabel("Permanence of Synapse")
+    if show:
+        plt.show()
+
+
+if __name__ == '__main__':
+    import argparse
+    # Accept location of data dump from command line
+    parser = argparse.ArgumentParser()
+    parser.add_argument('connections_save_file')
+    args = parser.parse_args()
+
+    # Load and run the connections object.
+    with open(args.connections_save_file, 'rb') as data_file:
+        data = data_file.read()
+
+    # TODO: Try both pickle and load, use whichever works.
+    C = Connections.load( data )
+    print("")
+    print( C )
+    segmentsPerCell( C, show=False)
+    potentialSynapsesPerSegment( C, show=False)
+    connectedSynapsesPerSegment( C, show=False)
+    permanences( C, show=False)
+    plt.show()

--- a/py/src/nupic/examples/connections_analysis.py
+++ b/py/src/nupic/examples/connections_analysis.py
@@ -21,6 +21,17 @@ import matplotlib.pyplot as plt
 from nupic.bindings.algorithms import Connections
 
 
+def main(connections, show=True):
+    print("")
+    print( connections )
+    segmentsPerCell( connections, show=False)
+    potentialSynapsesPerSegment( connections, show=False)
+    connectedSynapsesPerSegment( connections, show=False)
+    permanences( connections, show=False)
+    if show:
+        plt.show()
+
+
 def segmentsPerCell(connections, show=True):
     # Histogram of segments per cell
     data = []
@@ -100,10 +111,4 @@ if __name__ == '__main__':
 
     # TODO: Try both pickle and load, use whichever works.
     C = Connections.load( data )
-    print("")
-    print( C )
-    segmentsPerCell( C, show=False)
-    potentialSynapsesPerSegment( C, show=False)
-    connectedSynapsesPerSegment( C, show=False)
-    permanences( C, show=False)
-    plt.show()
+    main(C)

--- a/src/examples/mnist/MNIST_SP.cpp
+++ b/src/examples/mnist/MNIST_SP.cpp
@@ -25,6 +25,7 @@
 
 #include <cstdint> //uint8_t
 #include <iostream>
+#include <fstream>      // std::ofstream
 #include <vector>
 
 #include <nupic/algorithms/SpatialPooler.hpp>
@@ -79,6 +80,11 @@ void setup() {
     /* spVerbosity */                 1u,
     /* wrapAround */                  false); //wrap is false for this problem
 
+  // Save the connections to file for postmortem analysis.
+  ofstream dump("mnist_sp_initial.connections", ofstream::binary | ofstream::trunc | ofstream::out);
+  sp.connections.save( dump );
+  dump.close();
+
   clsr.initialize( /* alpha */ .001);
 
   dataset = mnist::read_dataset<std::vector, std::vector, uint8_t, uint8_t>(string("../ThirdParty/mnist_data/mnist-src/")); //from CMake
@@ -121,6 +127,11 @@ void train() {
   cout << "inputStats "  << inputStats << endl;
   cout << "columnStats " << columnStats << endl;
   cout << sp << endl;
+
+  // Save the connections to file for postmortem analysis.
+  ofstream dump("mnist_sp_learned.connections", ofstream::binary | ofstream::trunc | ofstream::out);
+  sp.connections.save( dump );
+  dump.close();
 }
 
 void test() {

--- a/src/nupic/algorithms/Connections.cpp
+++ b/src/nupic/algorithms/Connections.cpp
@@ -592,7 +592,7 @@ std::ostream& operator<< (std::ostream& stream, const Connections& self)
         const auto &synData = self.dataForSynapse( syn );
         if( synData.permanence == minPermanence )
           { synapsesDead++; }
-        else if( synData.permanence == minPermanence )
+        else if( synData.permanence == maxPermanence )
           { synapsesSaturated++; }
       }
     }

--- a/src/nupic/algorithms/Connections.hpp
+++ b/src/nupic/algorithms/Connections.hpp
@@ -507,15 +507,14 @@ public:
     }
   }
 
-
-  // Debugging
-
   /**
    * Gets the number of cells.
    *
    * @retval Number of cells.
    */
   size_t numCells() const { return cells_.size(); }
+
+  Permanence getConnectedThreshold() const { return connectedThreshold_; }
 
   /**
    * Gets the number of segments.

--- a/src/nupic/algorithms/SpatialPooler.hpp
+++ b/src/nupic/algorithms/SpatialPooler.hpp
@@ -1290,6 +1290,9 @@ protected:
 
   UInt version_;
   Random rng_;
+
+public:
+  const connections::Connections &connections = connections_;
 };
 
 } // end namespace spatial_pooler


### PR DESCRIPTION
For issue PR #243.

### Python Bindings for Connections Class
This adds python bindings for the connections class.  Currently it is a very thin wrapper around the C++ class.  In the future it should be extended to accept vectors of data, for practical speed.

TODO:
- [x] Python bindings for `connections::computeActivity()`

### Connections Analysis
This adds a program which shows histograms of:
- segmentsPerCell
- potentialSynapsesPerSegment
- connectedSynapsesPerSegment
- permanences

Run this program as:
`$ python3 -m nupic.examples.connections_analysis connections_save_file`

I've instrumented the MNIST example to save the connections before and after running to files `mnist_sp_initial.connections` and `mnist_sp_learned.connections`.  Here are some of the resulting histograms, from after training:

![Histogram_of_Connected_Synapses_per_Segment](https://user-images.githubusercontent.com/19578795/56920155-7c044400-6a90-11e9-8763-d29b1c8a7fdc.png)

![Histogram_of_Synapse_Permanences](https://user-images.githubusercontent.com/19578795/56920396-16648780-6a91-11e9-82ef-006d31fa8d02.png)
