### PR TITLE
Category Encoder

### DIFF
--- a/bindings/py/cpp_src/bindings/encoders/encoders_module.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/encoders_module.cpp
@@ -37,9 +37,7 @@ using namespace nupic_ext;
 
 PYBIND11_MODULE(encoders, m) {
     m.doc() =
-R"(nupic.bindings.encoders
-
-An encoder converts a value to a sparse distributed representation.
+R"(Encoders convert values into sparse distributed representation.
 
 There are several critical properties which all encoders must have:
 
@@ -54,6 +52,12 @@ There are several critical properties which all encoders must have:
     have enough active bits to handle noise and subsampling.
 
 Reference: https://arxiv.org/pdf/1602.05925.pdf
+
+
+CategoryEncoders:
+    To make encode categories of input, make either a ScalarEncoder or a
+RandomDistributedScalarEncoder, and set the "radius" parameter to 1.  Then
+enumerate your categories into integers before encoding them.
 )";
 
     init_ScalarEncoder(m);

--- a/bindings/py/tests/encoders/scalar_encoder_test.py
+++ b/bindings/py/tests/encoders/scalar_encoder_test.py
@@ -29,10 +29,6 @@ from nupic.bindings.encoders import ScalarEncoder, ScalarEncoderParameters
 from nupic.bindings.sdr import SDR, Metrics
 
 class ScalarEncoder_Test(unittest.TestCase):
-    @pytest.mark.skip("TODO UNIMPLEMENTED!")
-    def testExampleUsage(self):
-        1/0
-
     def testConstructor(self):
         p = ScalarEncoderParameters()
         p.size       = 1000
@@ -60,6 +56,33 @@ class ScalarEncoder_Test(unittest.TestCase):
         assert( list(sdr.sparse) == [0, 1, 2] )
         sdr2 = enc.encode( 1 )
         assert( list(sdr2.sparse) == [7, 8, 9] )
+
+    def testCategories(self):
+        # Test two categories.
+        p = ScalarEncoderParameters()
+        p.minimum    = 0
+        p.maximum    = 1
+        p.activeBits = 3
+        p.radius     = 1
+        enc = ScalarEncoder(p)
+        sdr = SDR( enc.dimensions )
+        zero = enc.encode( 0 )
+        one  = enc.encode( 1 )
+        assert( zero.getOverlap( one ) == 0 )
+        # Test three categories.
+        p = ScalarEncoderParameters()
+        p.minimum    = 0
+        p.maximum    = 2
+        p.activeBits = 3
+        p.radius     = 1
+        enc = ScalarEncoder(p)
+        sdr = SDR( enc.dimensions )
+        zero = enc.encode( 0 )
+        one  = enc.encode( 1 )
+        two  = enc.encode( 2 )
+        assert( zero.getOverlap( one ) == 0 )
+        assert( one.getOverlap( two ) == 0 )
+        assert( two.getSum() == 3 )
 
     def testBadParameters(self):
         # Start with sane parameters.

--- a/py/src/nupic/encoders/__init__.py
+++ b/py/src/nupic/encoders/__init__.py
@@ -1,0 +1,1 @@
+from nupic.bindings.encoders import __doc__

--- a/src/nupic/encoders/ScalarEncoder.cpp
+++ b/src/nupic/encoders/ScalarEncoder.cpp
@@ -78,10 +78,16 @@ void ScalarEncoder::initialize(ScalarEncoderParameters &parameters)
   }
 
   // Determine resolution & size.
-  Real64  maxInclusive     = args_.maximum;
-  UInt64* maxInclusiveData = (UInt64*)&maxInclusive;
-  (*maxInclusiveData)++; // Increase maxInclusive by the smallest possible amount.
-  const Real64 extentWidth = maxInclusive - args_.minimum;
+  Real64 extentWidth;
+  if( args_.periodic ) {
+    extentWidth = args_.maximum - args_.minimum;
+  }
+  else {
+    Real64  maxInclusive     = args_.maximum;
+    UInt64* maxInclusiveData = reinterpret_cast<UInt64*>( &maxInclusive );
+    (*maxInclusiveData)++; // Increase maxInclusive by the smallest possible amount.
+    extentWidth = maxInclusive - args_.minimum;
+  }
   if( args_.size > 0u ) {
     // Distribute the active bits along the domain [minimum, maximum], including
     // the endpoints. The resolution is the width of each band between the
@@ -132,16 +138,19 @@ void ScalarEncoder::encode(Real64 input, SDR &output)
     return;
   }
   else if( args_.clipInput ) {
-    input = std::max(input, parameters.minimum);
-    input = std::min(input, parameters.maximum);
+    if( args_.periodic ) {
+      // TODO: Apply modulus to inputs here!
+      NTA_THROW << "Unimplemented";
+    }
+    else {
+      input = std::max(input, parameters.minimum);
+      input = std::min(input, parameters.maximum);
+    }
   }
   else {
     NTA_CHECK(input >= parameters.minimum && input <= parameters.maximum)
         << "Input must be within range [minimum, maximum]!";
   }
-
-  auto &sparse = output.getSparse();
-  sparse.resize( parameters.activeBits );
 
   UInt start = (UInt) round((input - parameters.minimum) / parameters.resolution);
 
@@ -153,11 +162,15 @@ void ScalarEncoder::encode(Real64 input, SDR &output)
     start = std::min(start, output.size - parameters.activeBits);
   }
 
+  auto &sparse = output.getSparse();
+  sparse.resize( parameters.activeBits );
   std::iota( sparse.begin(), sparse.end(), start );
 
   if( parameters.periodic ) {
-    for(UInt wrap = output.size - start; wrap < parameters.activeBits; ++wrap) {
-      sparse[wrap] -= output.size;
+    for( auto & bit : sparse ) {
+      if( bit >= output.size ) {
+        bit -= output.size;
+      }
     }
   }
 

--- a/src/nupic/encoders/ScalarEncoder.cpp
+++ b/src/nupic/encoders/ScalarEncoder.cpp
@@ -28,7 +28,7 @@
 
 #include <algorithm> // std::min
 #include <numeric>   // std::iota
-#include <cmath>     // std::isnan
+#include <cmath>     // std::isnan std::nextafter
 #include <nupic/encoders/ScalarEncoder.hpp>
 using nupic::sdr::SDR;
 
@@ -83,9 +83,8 @@ void ScalarEncoder::initialize(ScalarEncoderParameters &parameters)
     extentWidth = args_.maximum - args_.minimum;
   }
   else {
-    Real64  maxInclusive     = args_.maximum;
-    UInt64* maxInclusiveData = reinterpret_cast<UInt64*>( &maxInclusive );
-    (*maxInclusiveData)++; // Increase maxInclusive by the smallest possible amount.
+    // Increase the max by the smallest possible amount.
+    Real64  maxInclusive = std::nextafter( args_.maximum, HUGE_VAL );
     extentWidth = maxInclusive - args_.minimum;
   }
   if( args_.size > 0u ) {

--- a/src/nupic/encoders/ScalarEncoder.cpp
+++ b/src/nupic/encoders/ScalarEncoder.cpp
@@ -78,7 +78,10 @@ void ScalarEncoder::initialize(ScalarEncoderParameters &parameters)
   }
 
   // Determine resolution & size.
-  const Real64 extentWidth = args_.maximum - args_.minimum;
+  Real64  maxInclusive     = args_.maximum;
+  UInt64* maxInclusiveData = (UInt64*)&maxInclusive;
+  (*maxInclusiveData)++; // Increase maxInclusive by the smallest possible amount.
+  const Real64 extentWidth = maxInclusive - args_.minimum;
   if( args_.size > 0u ) {
     // Distribute the active bits along the domain [minimum, maximum], including
     // the endpoints. The resolution is the width of each band between the

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -56,8 +56,8 @@ namespace encoders {
      * Member "periodic" controls what happens near the edges of the input
      * range.
      *
-     * If true, then the minimum & maximum input values are adjacent and the
-     * first and last bits of the output SDR are also adjacent.  The contiguous
+     * If true, then the minimum & maximum input values are the same and the
+     * first and last bits of the output SDR are adjacent.  The contiguous
      * block of 1's wraps around the end back to the begining.
      *
      * If false, then minimum & maximum input values are the endpoints of the

--- a/src/test/unit/encoders/ScalarEncoderTest.cpp
+++ b/src/test/unit/encoders/ScalarEncoderTest.cpp
@@ -152,7 +152,7 @@ TEST(ScalarEncoder, PeriodicRoundNearestMultipleOfResolution) {
   p.periodic   = true;
   ScalarEncoder encoder( p );
 
-  ASSERT_EQ(encoder.parameters.size, 11u);
+  ASSERT_EQ(encoder.parameters.size, 10u);
 
   std::vector<ScalarValueCase> cases = {
       {10.00f, {0, 1, 2}},
@@ -164,9 +164,9 @@ TEST(ScalarEncoder, PeriodicRoundNearestMultipleOfResolution) {
       {14.50f, {5, 6, 7}},
       {15.49f, {5, 6, 7}},
       {15.50f, {6, 7, 8}},
-      {19.49f, {9, 10, 0}},
-      {19.50f, {10, 0, 1}},
-      {20.00f, {10, 0, 1}}};
+      {19.49f, {9, 0, 1}},
+      {19.50f, {0, 1, 2}},
+      {20.00f, {0, 1, 2}}};
 
   doScalarValueCases(encoder, cases);
 }

--- a/src/test/unit/encoders/ScalarEncoderTest.cpp
+++ b/src/test/unit/encoders/ScalarEncoderTest.cpp
@@ -127,7 +127,7 @@ TEST(ScalarEncoder, RoundToNearestMultipleOfResolution) {
   p.resolution = 1;
   ScalarEncoder encoder( p );
 
-  ASSERT_EQ(encoder.parameters.size, 12u);
+  ASSERT_EQ(encoder.parameters.size, 13u);
 
   std::vector<ScalarValueCase> cases = {
       {10.00f, {0, 1, 2}},
@@ -139,9 +139,10 @@ TEST(ScalarEncoder, RoundToNearestMultipleOfResolution) {
       {14.50f, {5, 6, 7}},
       {15.49f, {5, 6, 7}},
       {15.50f, {6, 7, 8}},
+      {19.00f, {9, 10, 11}},
       {19.49f, {9, 10, 11}},
-      {19.50f, {9, 10, 11}},
-      {20.00f, {9, 10, 11}}};
+      {19.50f, {10, 11, 12}},
+      {20.00f, {10, 11, 12}}};
 
   doScalarValueCases(encoder, cases);
 }
@@ -155,7 +156,7 @@ TEST(ScalarEncoder, PeriodicRoundNearestMultipleOfResolution) {
   p.periodic   = true;
   ScalarEncoder encoder( p );
 
-  ASSERT_EQ(encoder.parameters.size, 10u);
+  ASSERT_EQ(encoder.parameters.size, 11u);
 
   std::vector<ScalarValueCase> cases = {
       {10.00f, {0, 1, 2}},
@@ -167,9 +168,9 @@ TEST(ScalarEncoder, PeriodicRoundNearestMultipleOfResolution) {
       {14.50f, {5, 6, 7}},
       {15.49f, {5, 6, 7}},
       {15.50f, {6, 7, 8}},
-      {19.49f, {9, 0, 1}},
-      {19.50f, {0, 1, 2}},
-      {20.00f, {0, 1, 2}}};
+      {19.49f, {9, 10, 0}},
+      {19.50f, {10, 0, 1}},
+      {20.00f, {10, 0, 1}}};
 
   doScalarValueCases(encoder, cases);
 }

--- a/src/test/unit/encoders/ScalarEncoderTest.cpp
+++ b/src/test/unit/encoders/ScalarEncoderTest.cpp
@@ -37,10 +37,6 @@ using nupic::sdr::SDR;
 using nupic::encoders::ScalarEncoder;
 using nupic::encoders::ScalarEncoderParameters;
 
-TEST(ScalarEncoder, testExampleUsage) {
-  // TODO
-}
-
 
 struct ScalarValueCase
 {


### PR DESCRIPTION
Category Encoder,
For issue #258.

Added Documentation describing how to make a category encoder.
Added unit test for encoding categories to the ScalarEncoder's unit tests.

This fixes the handling of maximum values so that the max value is
allocated bits in the representation.  Without this fix categories
can't be correctly represented.