### PR TITLE
Fix TM cells to columns

### DIFF
--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -76,6 +76,6 @@ longer accept a synapse permanence threshold argument. PR #305
 
 * SDRClassifier class is replaced by `Classifier` and `Predictor` classes.
 
-* TemporalMemory::getPredictiveCells() now returns a SDR. This ensures more convenient API and that the SDR object has correct
+* TemporalMemory::getPredictiveCells(), and getActiveCells() now return a SDR. This ensures more convenient API and that the SDR object has correct
   dimensions matching TM. use TM.getPredictiveCells().getSparse() to obtain the sparse vector as before. 
 

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -75,3 +75,7 @@ are ignored.  PR #271
 longer accept a synapse permanence threshold argument. PR #305
 
 * SDRClassifier class is replaced by `Classifier` and `Predictor` classes.
+
+* TemporalMemory::getPredictiveCells() now returns a SDR. This ensures more convenient API and that the SDR object has correct
+  dimensions matching TM. use TM.getPredictiveCells().getSparse() to obtain the sparse vector as before. 
+

--- a/API_CHANGELOG.md
+++ b/API_CHANGELOG.md
@@ -76,6 +76,6 @@ longer accept a synapse permanence threshold argument. PR #305
 
 * SDRClassifier class is replaced by `Classifier` and `Predictor` classes.
 
-* TemporalMemory::getPredictiveCells(), and getActiveCells() now return a SDR. This ensures more convenient API and that the SDR object has correct
+* TemporalMemory::getPredictiveCells() now returns a SDR. This ensures more convenient API and that the SDR object has correct
   dimensions matching TM. use TM.getPredictiveCells().getSparse() to obtain the sparse vector as before. 
 

--- a/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
@@ -151,9 +151,7 @@ using namespace nupic::algorithms::connections;
 
         py_HTM.def("getPredictiveCells", [](const HTM_t& self)
         {
-            auto predictiveCells = self.getPredictiveCells().getSparse();
-
-            return py::array_t<nupic::UInt32>(predictiveCells.size(), predictiveCells.data());
+            return self.getPredictiveCells();
         });
 
         py_HTM.def("getWinnerCells", [](const HTM_t& self)

--- a/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
@@ -151,7 +151,7 @@ using namespace nupic::algorithms::connections;
 
         py_HTM.def("getPredictiveCells", [](const HTM_t& self)
         {
-            auto predictiveCells = self.getPredictiveCells();
+            auto predictiveCells = self.getPredictiveCells().getSparse();
 
             return py::array_t<nupic::UInt32>(predictiveCells.size(), predictiveCells.data());
         });

--- a/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
@@ -139,7 +139,7 @@ using namespace nupic::algorithms::connections;
 
         py_HTM.def("getActiveCells", [](const HTM_t& self)
         {
-            auto activeCells = self.getActiveCells().getSparse();
+            auto activeCells = self.getActiveCells();
 
             return py::array_t<nupic::UInt32>(activeCells.size(), activeCells.data());
         });

--- a/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
@@ -139,7 +139,7 @@ using namespace nupic::algorithms::connections;
 
         py_HTM.def("getActiveCells", [](const HTM_t& self)
         {
-            auto activeCells = self.getActiveCells();
+            auto activeCells = self.getActiveCells().getSparse();
 
             return py::array_t<nupic::UInt32>(activeCells.size(), activeCells.data());
         });

--- a/src/examples/hotgym/HelloSPTP.cpp
+++ b/src/examples/hotgym/HelloSPTP.cpp
@@ -132,11 +132,7 @@ Real64 BenchmarkHotgym::run(UInt EPOCHS, bool useSPlocal, bool useSPglobal, bool
     tTM.start();
     tm.compute(outSP, true /*learn*/); //to uses output of SPglobal
     tm.activateDendrites(); //required to enable tm.getPredictiveCells()
-    auto correctDims = tm.getColumnDimensions();
-    correctDims.push_back(tm.getCellsPerColumn());
-    SDR cells(correctDims);
-    tm.getPredictiveCells(cells);
-    outTM = tm.cellsToColumns(cells);
+    outTM = tm.cellsToColumns( tm.getPredictiveCells() );
     tTM.stop();
     }
 

--- a/src/examples/hotgym/HelloSPTP.cpp
+++ b/src/examples/hotgym/HelloSPTP.cpp
@@ -132,7 +132,9 @@ Real64 BenchmarkHotgym::run(UInt EPOCHS, bool useSPlocal, bool useSPglobal, bool
     tTM.start();
     tm.compute(outSP, true /*learn*/); //to uses output of SPglobal
     tm.activateDendrites(); //required to enable tm.getPredictiveCells()
-    SDR cells({CELLS*COLS});
+    auto correctDims = tm.getColumnDimensions();
+    correctDims.push_back(tm.getCellsPerColumn());
+    SDR cells(correctDims);
     tm.getPredictiveCells(cells);
     outTM = tm.cellsToColumns(cells);
     tTM.stop();

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -714,29 +714,30 @@ void TemporalMemory::getActiveCells(SDR &activeCells) const
   activeCells.setSparse( getActiveCells() );
 }
 
-vector<CellIdx> TemporalMemory::getPredictiveCells() const {
+
+SDR TemporalMemory::getPredictiveCells() const {
 
   NTA_CHECK( segmentsValid_ )
     << "Call TM.activateDendrites() before TM.getPredictiveCells()!";
 
-  vector<CellIdx> predictiveCells;
+  auto correctDims = getColumnDimensions();
+  correctDims.push_back(getCellsPerColumn());
+  SDR predictive(correctDims);
+
+  auto& predictiveCells = predictive.getSparse();
 
   for (auto segment = activeSegments_.cbegin(); segment != activeSegments_.cend();
        segment++) {
-    CellIdx cell = connections.cellForSegment(*segment);
+    const CellIdx cell = connections.cellForSegment(*segment);
     if (segment == activeSegments_.begin() || cell != predictiveCells.back()) {
       predictiveCells.push_back(cell);
     }
   }
 
-  return predictiveCells;
+  predictive.setSparse(predictiveCells);
+  return predictive;
 }
 
-void TemporalMemory::getPredictiveCells(SDR &predictiveCells) const
-{
-  NTA_CHECK( predictiveCells.size == numberOfCells() );
-  predictiveCells.setSparse( getPredictiveCells() );
-}
 
 vector<CellIdx> TemporalMemory::getWinnerCells() const { return winnerCells_; }
 

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -677,7 +677,7 @@ SDR TemporalMemory::cellsToColumns(const SDR& cells) const {
   NTA_CHECK(cells.size == numberOfCells()) 
 	  << "cells.size " << cells.size << " must match TM::numberOfCells() " << numberOfCells();
 
-  SDR cols({numColumns_});
+  SDR cols(getColumnDimensions());
   auto& dense = cols.getDense();
   for(const auto cell : cells.getSparse()) {
     const auto col = columnForCell(cell);

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -583,7 +583,7 @@ void TemporalMemory::activateDendrites(bool learn,
     auto& activeVec = activeCells_.getSparse();
     for(const auto &active : extraActive) {
       NTA_ASSERT( active < extra_ );
-      activeVec.push_back( static_cast<CellIdx>(active + numberOfCells()) );
+      activeVec.push_back( static_cast<CellIdx>(active + numberOfCells()) ); 
     }
     activeCells_.setSparse(activeVec);
 

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -674,8 +674,11 @@ UInt TemporalMemory::columnForCell(const CellIdx cell) const {
 
 
 SDR TemporalMemory::cellsToColumns(const SDR& cells) const {
-  NTA_CHECK(cells.size == numberOfCells()) 
-	  << "cells.size " << cells.size << " must match TM::numberOfCells() " << numberOfCells();
+  auto correctDims = getColumnDimensions(); //nD column dimensions (eg 10x100)
+  correctDims.push_back(getCellsPerColumn()); //add n+1-th dimension for cellsPerColumn (eg. 10x100x8)
+
+  NTA_CHECK(cells.dimensions == correctDims) 
+	  << "cells.dimensions must match TM's (column dims x cellsPerColumn) ";
 
   SDR cols(getColumnDimensions());
   auto& dense = cols.getDense();

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -303,12 +303,9 @@ public:
   size_t numberOfCells(void) const { return connections.numCells(); }
 
   /**
-   * Returns the indices of the active cells.
-   *
-   * @returns (std::vector<CellIdx>) Vector of indices of active cells.
+   * @return SDR with indices of active cells.
    */
-  vector<CellIdx> getActiveCells() const; //TODO remove
-  void getActiveCells(sdr::SDR &activeCells) const;
+  sdr::SDR getActiveCells() const;
 
   /**
    * @return SDR with indices of the predictive cells.
@@ -613,7 +610,7 @@ protected:
   Permanence predictedSegmentDecrement_;
   UInt extra_;
 
-  vector<CellIdx> activeCells_;
+  sdr::SDR activeCells_;
   vector<CellIdx> winnerCells_;
   bool segmentsValid_;
   vector<Segment> activeSegments_;

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -303,9 +303,12 @@ public:
   size_t numberOfCells(void) const { return connections.numCells(); }
 
   /**
-   * @return SDR with indices of active cells.
+   * Returns the indices of the active cells.
+   *
+   * @returns (std::vector<CellIdx>) Vector of indices of active cells.
    */
-  sdr::SDR getActiveCells() const;
+  vector<CellIdx> getActiveCells() const; //TODO remove
+  void getActiveCells(sdr::SDR &activeCells) const;
 
   /**
    * @return SDR with indices of the predictive cells.
@@ -610,7 +613,7 @@ protected:
   Permanence predictedSegmentDecrement_;
   UInt extra_;
 
-  sdr::SDR activeCells_;
+  vector<CellIdx> activeCells_;
   vector<CellIdx> winnerCells_;
   bool segmentsValid_;
   vector<Segment> activeSegments_;

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -593,8 +593,9 @@ public:
    *
    *  @param const SDR& cells - input cells, size must be a multiple of cellsPerColumn; ie. 
    *    all SDRs obtained from TM's get*Cells(SDR) are valid. 
+   *    The SDR cells dimensions must be: {TM.getColumnDimensions, TM.getCellsPerColumn()}
    *
-   *  @return SDR cols - which is size of numCells/cellsPerColumn
+   *  @return SDR cols - which is size of TM's getColumnDimensions()
    *
    */
   sdr::SDR cellsToColumns(const sdr::SDR& cells) const;

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -311,12 +311,10 @@ public:
   void getActiveCells(sdr::SDR &activeCells) const;
 
   /**
-   * Returns the indices of the predictive cells.
-   *
-   * @returns (std::vector<CellIdx>) Vector of indices of predictive cells.
+   * @return SDR with indices of the predictive cells.
+   * SDR dimensions are {TM column dims x TM cells per column}
    */
-  vector<CellIdx> getPredictiveCells() const; //TODO remove?
-  void getPredictiveCells(sdr::SDR &predictiveCells) const;
+  sdr::SDR getPredictiveCells() const;
 
   /**
    * Returns the indices of the winner cells.

--- a/src/nupic/regions/TMRegion.cpp
+++ b/src/nupic/regions/TMRegion.cpp
@@ -248,21 +248,17 @@ void TMRegion::compute() {
   out = getOutput("bottomUpOut");
   if (out && (out->hasOutgoingLinks() || LogItem::isDebug())) {
     SDR& sdr = out->getData().getSDR();
-    if (args_.orColumnOutputs) { //aggregate to columns
-      SDR cols = tm_->cellsToColumns(tm_->getActiveCells());
-      sdr.setSparse(cols.getSparse());
-    } else { //output as cells
-      SDR cells = tm_->getActiveCells();
-      sdr.setSparse(cells.getSparse());
+    sdr = tm_->getActiveCells();
+    if (args_.orColumnOutputs) { //output as columns
+      SDR cols = tm_->cellsToColumns(sdr);
+      sdr.setSDR(cols);
     }
     NTA_DEBUG << "compute " << *out << std::endl;
   }
   out = getOutput("activeCells");
   if (out && (out->hasOutgoingLinks() || LogItem::isDebug())) {
     SDR& sdr = out->getData().getSDR();
-    SDR cells = tm_->getActiveCells();
-    sdr.setSparse(cells.getSparse());
-
+    sdr = tm_->getActiveCells();
     NTA_DEBUG << "compute " << *out << std::endl;
   }
   out = getOutput("predictedActiveCells");

--- a/src/nupic/regions/TMRegion.cpp
+++ b/src/nupic/regions/TMRegion.cpp
@@ -248,17 +248,21 @@ void TMRegion::compute() {
   out = getOutput("bottomUpOut");
   if (out && (out->hasOutgoingLinks() || LogItem::isDebug())) {
     SDR& sdr = out->getData().getSDR();
-    sdr = tm_->getActiveCells();
-    if (args_.orColumnOutputs) { //output as columns
-      SDR cols = tm_->cellsToColumns(sdr);
-      sdr.setSDR(cols);
+    if (args_.orColumnOutputs) { //aggregate to columns
+      SDR cols = tm_->cellsToColumns(tm_->getActiveCells());
+      sdr.setSparse(cols.getSparse());
+    } else { //output as cells
+      SDR cells = tm_->getActiveCells();
+      sdr.setSparse(cells.getSparse());
     }
     NTA_DEBUG << "compute " << *out << std::endl;
   }
   out = getOutput("activeCells");
   if (out && (out->hasOutgoingLinks() || LogItem::isDebug())) {
     SDR& sdr = out->getData().getSDR();
-    sdr = tm_->getActiveCells();
+    SDR cells = tm_->getActiveCells();
+    sdr.setSparse(cells.getSparse());
+
     NTA_DEBUG << "compute " << *out << std::endl;
   }
   out = getOutput("predictedActiveCells");

--- a/src/nupic/regions/TMRegion.cpp
+++ b/src/nupic/regions/TMRegion.cpp
@@ -248,18 +248,17 @@ void TMRegion::compute() {
   out = getOutput("bottomUpOut");
   if (out && (out->hasOutgoingLinks() || LogItem::isDebug())) {
     SDR& sdr = out->getData().getSDR();
-    if (args_.orColumnOutputs) { //aggregate to columns
-      tm_->getActiveCells(sdr);
+    sdr = tm_->getActiveCells();
+    if (args_.orColumnOutputs) { //output as columns
       SDR cols = tm_->cellsToColumns(sdr);
-      sdr.setSparse(cols.getSparse());
-    } else { //output as cells
-      tm_->getActiveCells(sdr);
+      sdr.setSDR(cols);
     }
     NTA_DEBUG << "compute " << *out << std::endl;
   }
   out = getOutput("activeCells");
   if (out && (out->hasOutgoingLinks() || LogItem::isDebug())) {
-    tm_->getActiveCells(out->getData().getSDR());
+    SDR& sdr = out->getData().getSDR();
+    sdr = tm_->getActiveCells();
     NTA_DEBUG << "compute " << *out << std::endl;
   }
   out = getOutput("predictedActiveCells");

--- a/src/nupic/regions/TMRegion.cpp
+++ b/src/nupic/regions/TMRegion.cpp
@@ -248,17 +248,18 @@ void TMRegion::compute() {
   out = getOutput("bottomUpOut");
   if (out && (out->hasOutgoingLinks() || LogItem::isDebug())) {
     SDR& sdr = out->getData().getSDR();
-    sdr = tm_->getActiveCells();
-    if (args_.orColumnOutputs) { //output as columns
+    if (args_.orColumnOutputs) { //aggregate to columns
+      tm_->getActiveCells(sdr);
       SDR cols = tm_->cellsToColumns(sdr);
-      sdr.setSDR(cols);
+      sdr.setSparse(cols.getSparse());
+    } else { //output as cells
+      tm_->getActiveCells(sdr);
     }
     NTA_DEBUG << "compute " << *out << std::endl;
   }
   out = getOutput("activeCells");
   if (out && (out->hasOutgoingLinks() || LogItem::isDebug())) {
-    SDR& sdr = out->getData().getSDR();
-    sdr = tm_->getActiveCells();
+    tm_->getActiveCells(out->getData().getSDR());
     NTA_DEBUG << "compute " << *out << std::endl;
   }
   out = getOutput("predictedActiveCells");

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -115,7 +115,7 @@ TEST(TemporalMemoryTest, ActivateCorrectlyPredictiveCells) {
   ASSERT_EQ(expectedActiveCells, tm.getPredictiveCells().getSparse());
   tm.compute(numActiveColumns, activeColumns, true);
 
-  EXPECT_EQ(expectedActiveCells, tm.getActiveCells());
+  EXPECT_EQ(expectedActiveCells, tm.getActiveCells().getSparse());
 }
 
 /**
@@ -141,7 +141,7 @@ TEST(TemporalMemoryTest, BurstUnpredictedColumns) {
 
   tm.compute(1, activeColumns, true);
 
-  EXPECT_EQ(burstingCells, tm.getActiveCells());
+  EXPECT_EQ(burstingCells, tm.getActiveCells().getSparse());
 }
 
 /**
@@ -175,13 +175,13 @@ TEST(TemporalMemoryTest, ZeroActiveColumns) {
   tm.connections.createSynapse(segment, previousActiveCells[2], 0.5f);
   tm.connections.createSynapse(segment, previousActiveCells[3], 0.5f);
   tm.compute(1, previousActiveColumns, true);
-  ASSERT_FALSE(tm.getActiveCells().empty());
+  ASSERT_FALSE(tm.getActiveCells().getSum() == 0);
   ASSERT_FALSE(tm.getWinnerCells().empty());
   tm.activateDendrites();
   ASSERT_FALSE(tm.getPredictiveCells().getSum() == 0);
 
   EXPECT_NO_THROW(tm.compute(0, nullptr, true)) << "failed with empty compute";
-  EXPECT_TRUE(tm.getActiveCells().empty());
+  EXPECT_TRUE(tm.getActiveCells().getSum() == 0);
   EXPECT_TRUE(tm.getWinnerCells().empty());
   tm.activateDendrites();
   EXPECT_TRUE(tm.getPredictiveCells().getSum() == 0);
@@ -1053,7 +1053,7 @@ TEST(TemporalMemoryTest, AddSegmentToCellWithFewestSegments) {
     tm.compute(4, previousActiveColumns, true);
     tm.compute(1, activeColumns, true);
 
-    ASSERT_EQ(activeCells, tm.getActiveCells());
+    ASSERT_EQ(activeCells, tm.getActiveCells().getSparse());
 
     EXPECT_EQ(3ul, tm.connections.numSegments());
     EXPECT_EQ(1ul, tm.connections.segmentsForCell(0).size());
@@ -1443,7 +1443,7 @@ void serializationTestVerify(TemporalMemory &tm) {
 
   // Verify the correct cells were activated.
   EXPECT_EQ((vector<UInt>{4, 8, 9, 10, 11, 12, 13, 14, 15}),
-            tm.getActiveCells());
+            tm.getActiveCells().getSparse());
   const vector<UInt> winnerCells = tm.getWinnerCells();
   ASSERT_EQ(3ul, winnerCells.size());
   EXPECT_EQ(4ul, winnerCells[0]);
@@ -1615,7 +1615,7 @@ TEST(TemporalMemoryTest, testExtraActive) {
       SDR predictedColumns = tm.cellsToColumns(tm.getPredictiveCells());
       // Calculate TM output
       tm.compute(x, true);
-      extraActive  = tm.getActiveCells();
+      extraActive  = tm.getActiveCells().getSparse();
       extraWinners = tm.getWinnerCells();
 
       // Calculate Anomaly of current input based on prior predictions.

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -115,7 +115,7 @@ TEST(TemporalMemoryTest, ActivateCorrectlyPredictiveCells) {
   ASSERT_EQ(expectedActiveCells, tm.getPredictiveCells().getSparse());
   tm.compute(numActiveColumns, activeColumns, true);
 
-  EXPECT_EQ(expectedActiveCells, tm.getActiveCells().getSparse());
+  EXPECT_EQ(expectedActiveCells, tm.getActiveCells());
 }
 
 /**
@@ -141,7 +141,7 @@ TEST(TemporalMemoryTest, BurstUnpredictedColumns) {
 
   tm.compute(1, activeColumns, true);
 
-  EXPECT_EQ(burstingCells, tm.getActiveCells().getSparse());
+  EXPECT_EQ(burstingCells, tm.getActiveCells());
 }
 
 /**
@@ -175,13 +175,13 @@ TEST(TemporalMemoryTest, ZeroActiveColumns) {
   tm.connections.createSynapse(segment, previousActiveCells[2], 0.5f);
   tm.connections.createSynapse(segment, previousActiveCells[3], 0.5f);
   tm.compute(1, previousActiveColumns, true);
-  ASSERT_FALSE(tm.getActiveCells().getSum() == 0);
+  ASSERT_FALSE(tm.getActiveCells().empty());
   ASSERT_FALSE(tm.getWinnerCells().empty());
   tm.activateDendrites();
   ASSERT_FALSE(tm.getPredictiveCells().getSum() == 0);
 
   EXPECT_NO_THROW(tm.compute(0, nullptr, true)) << "failed with empty compute";
-  EXPECT_TRUE(tm.getActiveCells().getSum() == 0);
+  EXPECT_TRUE(tm.getActiveCells().empty());
   EXPECT_TRUE(tm.getWinnerCells().empty());
   tm.activateDendrites();
   EXPECT_TRUE(tm.getPredictiveCells().getSum() == 0);
@@ -1053,7 +1053,7 @@ TEST(TemporalMemoryTest, AddSegmentToCellWithFewestSegments) {
     tm.compute(4, previousActiveColumns, true);
     tm.compute(1, activeColumns, true);
 
-    ASSERT_EQ(activeCells, tm.getActiveCells().getSparse());
+    ASSERT_EQ(activeCells, tm.getActiveCells());
 
     EXPECT_EQ(3ul, tm.connections.numSegments());
     EXPECT_EQ(1ul, tm.connections.segmentsForCell(0).size());
@@ -1443,7 +1443,7 @@ void serializationTestVerify(TemporalMemory &tm) {
 
   // Verify the correct cells were activated.
   EXPECT_EQ((vector<UInt>{4, 8, 9, 10, 11, 12, 13, 14, 15}),
-            tm.getActiveCells().getSparse());
+            tm.getActiveCells());
   const vector<UInt> winnerCells = tm.getWinnerCells();
   ASSERT_EQ(3ul, winnerCells.size());
   EXPECT_EQ(4ul, winnerCells[0]);
@@ -1615,7 +1615,7 @@ TEST(TemporalMemoryTest, testExtraActive) {
       SDR predictedColumns = tm.cellsToColumns(tm.getPredictiveCells());
       // Calculate TM output
       tm.compute(x, true);
-      extraActive  = tm.getActiveCells().getSparse();
+      extraActive  = tm.getActiveCells();
       extraWinners = tm.getWinnerCells();
 
       // Calculate Anomaly of current input based on prior predictions.

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -1358,7 +1358,9 @@ TEST(TemporalMemoryTest, testCellsToColumns)
   TemporalMemory tm;
   tm.initialize(vector<UInt>{3}, 3); // TM 3 cols x 3 cells per col
 
-  SDR v1({3*3});
+  auto correctDims = tm.getColumnDimensions();
+  correctDims.push_back(tm.getCellsPerColumn());
+  SDR v1(correctDims);
   v1.setSparse(SDR_sparse_t{4,5,8});
   const SDR_sparse_t expected {1u, 2u};
 
@@ -1369,8 +1371,11 @@ TEST(TemporalMemoryTest, testCellsToColumns)
   res = tm.cellsToColumns(v1);
   EXPECT_TRUE(res.getSparse().empty());
 
-  SDR larger({10,10});
+  SDR larger({10,10, 3});
   EXPECT_ANY_THROW(tm.cellsToColumns(larger));
+
+  SDR wrongDims({3*3}); //matches numberOfCells, but dimensions are incorrect
+  EXPECT_ANY_THROW(tm.cellsToColumns(wrongDims));
 };
 
 


### PR DESCRIPTION
- [x] TM::cellsToColumns(SDR cells) has stricter dimension requirements on arg cell, fixes for #406 
- [x] TM::getPredictiveCells() returns SDR, remove alt version with vector
- [ ] TM::getActiveCells() returns SDR, remove alt version with vector -> causes problem, will be a separate PR
  - these cause small, documented API breakage
  - TM uses `SDR activeCells_` internally
  - improved tests

Needed for #406 