### PR TITLE
Prototype Anomaly metric inside of Temporal Memory.

### DIFF
--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -47,6 +47,7 @@
 
 #include <nupic/utils/GroupBy.hpp>
 #include <nupic/math/Math.hpp> // nupic::Epsilon
+#include <nupic/algorithms/Anomaly.hpp>
 
 using namespace std;
 using namespace nupic;
@@ -633,6 +634,7 @@ void TemporalMemory::compute(const size_t        activeColumnsSize,
                              const vector<UInt> &extraWinners)
 {
   activateDendrites(learn, extraActive, extraWinners);
+  // TODO: Implement the anomaly metric here.
   activateCells(activeColumnsSize, activeColumns, learn);
 }
 
@@ -641,12 +643,21 @@ void TemporalMemory::compute(const SDR &activeColumns, bool learn,
                              const SDR &extraWinners)
 {
   activateDendrites(learn, extraActive, extraWinners);
+
+  // Update Anomaly Metric.  The anomaly is the percent of active columns that
+  // were not predicted.
+  anomaly_ = nupic::algorithms::anomaly::computeRawAnomalyScore(
+                activeColumns,
+                cellsToColumns( getPredictiveCells() ));
+  // TODO: Update mean & standard deviation of anomaly here.
+
   activateCells(activeColumns, learn);
 }
 
 void TemporalMemory::compute(const SDR &activeColumns, bool learn) {
-  activateDendrites(learn);
-  activateCells(activeColumns, learn);
+  SDR extraActive({ extra });
+  SDR extraWinners({ extra });
+  compute( activeColumns, learn, extraActive, extraWinners );
 }
 
 void TemporalMemory::reset(void) {
@@ -655,6 +666,7 @@ void TemporalMemory::reset(void) {
   activeSegments_.clear();
   matchingSegments_.clear();
   segmentsValid_ = false;
+  anomaly_ = -1;
 }
 
 // ==============================

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -626,11 +626,18 @@ protected:
   UInt64 iteration_;
   vector<UInt64> lastUsedIterationForSegment_;
 
+  Real anomaly_;
+
   Random rng_;
 
 public:
   Connections connections; //TODO not public!
   const UInt &extra = extra_;
+  /*
+   *  anomaly score computed for the current inputs
+   *  (auto-updates after each call to TM::compute())
+   */
+  const Real &anomaly = anomaly_;
 };
 
 } // end namespace temporal_memory


### PR DESCRIPTION
@Breznak,
I moved the call to RawAnomaly into the main compute method.  This works with the external inputs.

Currently anomaly is always computed.  We can add a flag to optionally disable the computation for users who care more about speed that diagnostics.

Alternative to PR #406.

Outstanding Tasks:
- [ ] Mean & StdDev for anomaly metric?
- [x] Fix legacy TM::compute method.
- [ ] Python bindings