### PR TITLE
SDR stop auto-cast from vector

### DIFF
--- a/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
@@ -139,7 +139,7 @@ using namespace nupic::algorithms::connections;
         });
 
         py_HTM.def("activateDendrites", [](HTM_t &self, bool learn) {
-            SDR extra({ self.extra });
+            SDR extra({ self.extra }, {});
             self.activateDendrites(learn, extra, extra);
         });
 

--- a/bindings/py/cpp_src/bindings/encoders/py_RDSE.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_RDSE.cpp
@@ -106,7 +106,7 @@ fields are filled in automatically.)");
         py_RDSE.def("encode", &RDSE::encode, R"()");
 
         py_RDSE.def("encode", [](RDSE &self, Real64 value) {
-            auto sdr = new sdr::SDR({self.size});
+            auto sdr = new sdr::SDR({self.size}, {});
             self.encode(value, *sdr);
             return sdr;
         });

--- a/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
@@ -116,7 +116,7 @@ fields are filled in automatically.)");
     py_ScalarEnc.def("encode", &ScalarEncoder::encode, R"()");
 
     py_ScalarEnc.def("encode", [](ScalarEncoder &self, nupic::Real64 value) {
-        auto output = new SDR( self.dimensions );
+        auto output = new SDR( self.dimensions, {} );
         self.encode( value, *output );
         return output; },
 R"()");

--- a/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
+++ b/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
@@ -106,16 +106,18 @@ re-access the data from the SDR.  Examples:
 )");
 
         py_SDR.def(
-            py::init<vector<UInt>>(),
+            py::init( [](vector<UInt> dimensions, SDR_sparse_t initialData) {
+		 return new SDR(dimensions, initialData);   }),
 R"(Create an SDR object.  The initial value is all zeros.
 
 Argument dimensions is a list of dimension sizes, defining the shape of the SDR.
 The product of the dimensions must be greater than zero.)",
-            py::arg("dimensions"));
+            py::arg("dimensions"),
+	    py::arg("initialData"));
 
         py_SDR.def(
             py::init( [](UInt dimensions) {
-                return new SDR({ dimensions }); }),
+                return new SDR({ dimensions }, {}); }),
 R"(Create an SDR object.  The initial value is all zeros.
 
 Argument dimensions is a single integer dimension size, defining a 1-dimensional

--- a/src/nupic/algorithms/Anomaly.cpp
+++ b/src/nupic/algorithms/Anomaly.cpp
@@ -50,7 +50,7 @@ Real computeRawAnomalyScore(const SDR& active,
   NTA_CHECK(active.dimensions == predicted.dimensions);
 
   // Calculate and return percent of active columns that were not predicted.
-  SDR both(active.dimensions);
+  SDR both(active.dimensions, SDR_sparse_t{});
   both.intersection(active, predicted);
 
   return (active.getSum() - both.getSum()) / Real(active.getSum());

--- a/src/nupic/algorithms/SpatialPooler.cpp
+++ b/src/nupic/algorithms/SpatialPooler.cpp
@@ -38,7 +38,7 @@ using namespace std;
 using namespace nupic;
 using namespace nupic::algorithms::spatial_pooler;
 using namespace nupic::math::topology;
-using nupic::sdr::SDR;
+using namespace nupic::sdr;
 using nupic::utils::VectorHelpers;
 
 class CoordinateConverterND {
@@ -479,10 +479,10 @@ void SpatialPooler::initialize(
 
 
 void SpatialPooler::compute(const UInt inputArray[], bool learn, UInt activeArray[]) {
-  SDR input( inputDimensions_ );
+  SDR input( inputDimensions_, SDR_sparse_t{});
   input.setDense( inputArray );
 
-  SDR active( columnDimensions_ );
+  SDR active( columnDimensions_, SDR_sparse_t{} );
   compute( input, learn, active );
   copy(
       active.getDense().begin(),
@@ -665,11 +665,11 @@ void SpatialPooler::updateDutyCycles_(const vector<SynapseIdx> &overlaps,
 
   // Turn the overlaps array into an SDR. Convert directly to flat-sparse to
   // avoid copies and  type convertions.
-  SDR newOverlap({ numColumns_ });
+  SDR newOverlap({ numColumns_}, SDR_sparse_t{});
   auto &overlapsSparseVec = newOverlap.getSparse();
   for (UInt i = 0; i < numColumns_; i++) {
     if( overlaps[i] != 0 )
-      overlapsSparseVec.push_back( i );
+      overlapsSparseVec.push_back( i ); //TODO use setDense overlaps
   }
   newOverlap.setSparse( overlapsSparseVec );
 

--- a/src/nupic/algorithms/TemporalMemory.cpp
+++ b/src/nupic/algorithms/TemporalMemory.cpp
@@ -651,11 +651,12 @@ SDR TemporalMemory::cellsToColumns(const SDR& cells) const {
 	  << "cells.dimensions must match TM's (column dims x cellsPerColumn) ";
 
   SDR cols(getColumnDimensions(), SDR_sparse_t{});
-  auto& s = cols.getSparse();
+  auto& dense = cols.getDense();
   for(const auto cell : cells.getSparse()) {
     const auto col = columnForCell(cell);
-    s.push_back(col);
+    dense[col] = static_cast<ElemDense>(1); //using dense (and not sparse) here to avoid duplicit entries
   }
+  cols.setDense(dense);
   NTA_ASSERT(cols.size == numColumns_); 
   return cols;
 }

--- a/src/nupic/algorithms/TemporalMemory.hpp
+++ b/src/nupic/algorithms/TemporalMemory.hpp
@@ -232,8 +232,8 @@ public:
 			 const sdr::SDR &extraWinners);
 
   inline void activateDendrites(const bool learn = true) {
-    const sdr::SDR extraActive(std::vector<UInt>{ extra });
-    const sdr::SDR extraWinners(std::vector<UInt>{extra });
+    const sdr::SDR extraActive(std::vector<UInt>{ extra }, sdr::SDR_sparse_t{});
+    const sdr::SDR extraWinners(std::vector<UInt>{extra }, sdr::SDR_sparse_t{});
     activateDendrites(learn, extraActive, extraWinners);
   }
 

--- a/src/nupic/encoders/BaseEncoder.hpp
+++ b/src/nupic/encoders/BaseEncoder.hpp
@@ -73,7 +73,7 @@ protected:
 
     void initialize(const std::vector<UInt> dimensions) {
         dimensions_ = dimensions;
-        size_       = sdr::SDR(dimensions).size;
+        size_       = sdr::SDR(dimensions, sdr::SDR_sparse_t{}).size;
     }
 
 private:

--- a/src/nupic/math/Topology.cpp
+++ b/src/nupic/math/Topology.cpp
@@ -30,7 +30,7 @@
 using std::vector;
 using namespace nupic;
 using namespace nupic::math::topology;
-using nupic::sdr::SDR;
+using namespace nupic::sdr;
 
 namespace nupic {
 namespace math {
@@ -65,7 +65,7 @@ Topology_t  DefaultTopology(
                               (inputTopology[i] / (Real)cell.dimensions[i]);
       inputCoords.push_back({ (UInt32)floor(inputCoord) });
     }
-    SDR inputTopologySDR( inputTopology );
+    SDR inputTopologySDR( inputTopology, SDR_sparse_t{} );
     inputTopologySDR.setCoordinates( inputCoords );
     const auto centerInput = inputTopologySDR.getSparse()[0];
 
@@ -88,8 +88,7 @@ Topology_t  DefaultTopology(
 
     const UInt numPotential = (UInt)round(columnInputs.size() * potentialPct);
     const auto selectedInputs = rng.sample<UInt>(columnInputs, numPotential);
-    SDR potentialPool( potentialPoolDimensions );
-    potentialPool.setSparse( selectedInputs );
+    const SDR potentialPool( potentialPoolDimensions, selectedInputs );
     return potentialPool;
   };
 }
@@ -100,7 +99,7 @@ Topology_t NoTopology(Real potentialPct)
   NTA_CHECK( potentialPct >= 0.0f );
   NTA_CHECK( potentialPct <= 1.0f );
   return [=](const SDR& cell, const vector<UInt>& potentialPoolDimensions, Random &rng) -> SDR {
-    SDR potentialPool( potentialPoolDimensions );
+    SDR potentialPool( potentialPoolDimensions, SDR_sparse_t{} );
     potentialPool.randomize( potentialPct, rng );
     return potentialPool;
   };

--- a/src/nupic/ntypes/ArrayBase.cpp
+++ b/src/nupic/ntypes/ArrayBase.cpp
@@ -113,7 +113,7 @@ char *ArrayBase::allocateBuffer(size_t count) {
 
 char *ArrayBase::allocateBuffer( const std::vector<UInt>& dimensions) { // only for SDR
   NTA_CHECK(type_ == NTA_BasicType_SDR) << "Dimensions can only be set on the SDR payload";
-  sdr::SDR *sdr = new sdr::SDR(dimensions);
+  sdr::SDR *sdr = new sdr::SDR(dimensions, sdr::SDR_sparse_t{});
   std::shared_ptr<char> sp(reinterpret_cast<char *>(sdr));
   buffer_ = sp;
   count_ = sdr->size;

--- a/src/nupic/regions/TMRegion.cpp
+++ b/src/nupic/regions/TMRegion.cpp
@@ -217,7 +217,7 @@ void TMRegion::compute() {
   SDR& activeColumns = bottomUpIn.getSDR();
 
   // Check for 'extra' inputs
-  static SDR nullSDR({0});
+  static SDR nullSDR({0}, sdr::SDR_sparse_t{});
   Array &extraActive = getInput("extraActive")->getData();
   SDR& extraActiveCells = (args_.extra) ? (extraActive.getSDR()) : nullSDR;
 

--- a/src/nupic/types/Sdr.cpp
+++ b/src/nupic/types/Sdr.cpp
@@ -132,8 +132,8 @@ namespace sdr {
 
     SparseDistributedRepresentation::SparseDistributedRepresentation(
                                 const SparseDistributedRepresentation &value )
-        : SparseDistributedRepresentation( value.dimensions )
-        { setSDR( value ); }
+        : SparseDistributedRepresentation( value.dimensions , value.getSparse())
+        { }
 
     SparseDistributedRepresentation::~SparseDistributedRepresentation()
         { deconstruct(); }
@@ -555,7 +555,7 @@ namespace sdr {
     /**************************************************************************/
 
     Reshape::Reshape(const SDR &sdr, const vector<UInt> &dimensions)
-        : SDR( dimensions )
+        : SDR( dimensions, sdr.getSparse() )
     {
         clear();
         parent = &sdr;
@@ -582,8 +582,8 @@ namespace sdr {
     SDR_coordinate_t& Reshape::getCoordinates() const {
         NTA_CHECK( parent != nullptr ) << "Parent SDR has been destroyed!";
         if( dimensions.size() == parent->dimensions.size() &&
-            equal( dimensions.begin(), dimensions.end(),
-                   parent->dimensions.begin() )) {
+            equal( dimensions.cbegin(), dimensions.cend(),
+                   parent->dimensions.cbegin() )) {
             // All things equal, prefer reusing the parent's cached value.
             return parent->getCoordinates();
         }

--- a/src/nupic/types/Sdr.cpp
+++ b/src/nupic/types/Sdr.cpp
@@ -101,10 +101,12 @@ namespace sdr {
     //constructors
     SparseDistributedRepresentation::SparseDistributedRepresentation() {}
 
-    SparseDistributedRepresentation::SparseDistributedRepresentation( const vector<UInt> dimensions )
-        { initialize( dimensions ); }
+    SparseDistributedRepresentation::SparseDistributedRepresentation( const vector<UInt> dimensions, 
+		                                                      const SDR_sparse_t data )
+        { initialize( dimensions, data ); }
 
-    void SparseDistributedRepresentation::initialize( const vector<UInt> dimensions ) {
+    void SparseDistributedRepresentation::initialize( const vector<UInt> dimensions,
+		                                      const SDR_sparse_t data ) {
         dimensions_ = dimensions;
         NTA_CHECK( dimensions.size() > 0 ) << "SDR has no dimensions!";
 
@@ -121,10 +123,11 @@ namespace sdr {
         // Initialize the dense array storage, when it's needed.
         dense_valid = false;
         // Initialize the flatSparse array, nothing to do.
-        sparse_valid = true;
-        // Initialize the index tuple.
-        coordinates_.assign( dimensions.size(), {} );
-        coordinates_valid = true;
+	sparse_ = data;
+	setSparseInplace();
+        // Initialize the coordinate format only when it's needed.
+	coordinates_.assign( dimensions.size(), {} );
+        coordinates_valid = false;
     }
 
     SparseDistributedRepresentation::SparseDistributedRepresentation(
@@ -436,9 +439,9 @@ namespace sdr {
         }
         // Check data
         return std::equal(
-            getDense().begin(),
-            getDense().end(), 
-            sdr.getDense().begin());
+            getDense().cbegin(),
+            getDense().cend(), 
+            sdr.getDense().cbegin());
     }
 
 

--- a/src/nupic/types/Sdr.hpp
+++ b/src/nupic/types/Sdr.hpp
@@ -219,7 +219,7 @@ public:
      *
      */
     SparseDistributedRepresentation( const std::vector<UInt> dimensions,
-		                     const SDR_sparse_t data = SDR_sparse_t{});
+		                     const SDR_sparse_t data);
 
     void initialize( const std::vector<UInt> dimensions,
 		     const SDR_sparse_t data = SDR_sparse_t{} );

--- a/src/nupic/types/Sdr.hpp
+++ b/src/nupic/types/Sdr.hpp
@@ -213,10 +213,16 @@ public:
      *
      * @param dimensions A list of dimension sizes, defining the shape of the
      * SDR.  The product of the dimensions must be greater than zero.
+     *
+     * @param (optional) data: default (sparse) data, same as calling sdr.setSparse(data);
+     * Default value is empty{}.
+     *
      */
-    SparseDistributedRepresentation( const std::vector<UInt> dimensions );
+    SparseDistributedRepresentation( const std::vector<UInt> dimensions,
+		                     const SDR_sparse_t data = SDR_sparse_t{});
 
-    void initialize( const std::vector<UInt> dimensions );
+    void initialize( const std::vector<UInt> dimensions,
+		     const SDR_sparse_t data = SDR_sparse_t{} );
 
     /**
      * Initialize this SDR as a deep copy of the given SDR.  This SDR and the
@@ -571,16 +577,14 @@ public:
     template<class Archive>
     void save_ar(Archive & ar) const
     {
-        getSparse(); // to make sure sparse is valid.
-        ar(cereal::make_nvp("dimensions", dimensions_), cereal::make_nvp("sparse", sparse_) );
+        ar(cereal::make_nvp("dimensions", dimensions_), cereal::make_nvp("sparse", getSparse()) );
     }
 
     template<class Archive>
     void load_ar(Archive & ar)
     {
         ar( dimensions_, sparse_ );
-        initialize( dimensions_ );
-        setSparseInplace();
+        initialize( dimensions_, sparse_ );
     }
 
     /**

--- a/src/nupic/utils/SdrMetrics.cpp
+++ b/src/nupic/utils/SdrMetrics.cpp
@@ -222,12 +222,12 @@ std::ostream& operator<< (std::ostream& stream,
 
 Overlap::Overlap( const vector<UInt> &dimensions, UInt period )
     : MetricsHelper_( dimensions, period ),
-      previous_( dimensions )
+      previous_( dimensions, SDR_sparse_t{} )
     { initialize(); }
 
 Overlap::Overlap( const SDR &dataSource, UInt period )
     : MetricsHelper_( dataSource, period ),
-      previous_( dataSource.dimensions )
+      previous_( dataSource.dimensions, SDR_sparse_t{} )
     { initialize(); }
 
 void Overlap::initialize() {

--- a/src/test/unit/algorithms/AnomalyTest.cpp
+++ b/src/test/unit/algorithms/AnomalyTest.cpp
@@ -36,42 +36,34 @@ using namespace nupic;
 using namespace nupic::sdr;
 
 TEST(ComputeRawAnomalyScore, NoActiveOrPredicted) {
-  SDR active({10});
-  SDR predicted({10});
+  SDR active({10}, {});
+  SDR predicted({10}, {});
   ASSERT_FLOAT_EQ(computeRawAnomalyScore(active, predicted), 0.0);
 };
 
 TEST(ComputeRawAnomalyScore, NoActive) {
-  SDR active({10});
-  SDR predicted({10});
-  predicted.setSparse(SDR_sparse_t{3,5});
-
+  SDR active({10}, {});
+  SDR predicted({10}, {3,5});
   ASSERT_FLOAT_EQ(computeRawAnomalyScore(active, predicted), 0.0f);
 };
 
 TEST(ComputeRawAnomalyScore, PerfectMatch) {
-  SDR active({10});
-  SDR predicted({10});
-  active.setSparse(SDR_sparse_t{3,5,7});
-  predicted.setSparse(SDR_sparse_t{3,5,7});
+  SDR active({10}, {3,5,7});
+  SDR predicted({10}, {3,5,7});
 
   ASSERT_FLOAT_EQ(computeRawAnomalyScore(active, predicted), 0.0f);
 };
 
 TEST(ComputeRawAnomalyScore, NoMatch) {
-  SDR active({10});
-  SDR predicted({10});
-  active.setSparse(SDR_sparse_t{2,4,6});
-  predicted.setSparse(SDR_sparse_t{3,5,7});
+  SDR active({10}, {2,4,6});
+  SDR predicted({10}, {3,5,7});
 
   ASSERT_FLOAT_EQ(computeRawAnomalyScore(active, predicted), 1.0f);
 };
 
 TEST(ComputeRawAnomalyScore, PartialMatch) {
-  SDR active({10});
-  SDR predicted({10});
-  active.setSparse(SDR_sparse_t{2,3,6});
-  predicted.setSparse(SDR_sparse_t{3,5,7}); // 1 out of 3 matches -> 66.6% anomaly = 2/3
+  SDR active({10}, {2,3,6});
+  SDR predicted({10}, {3,5,7}); // 1 out of 3 matches -> 66.6% anomaly = 2/3
 
   ASSERT_FLOAT_EQ(computeRawAnomalyScore(active, predicted), 2.0f / 3.0f);
 };

--- a/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsPerformanceTest.cpp
@@ -64,7 +64,7 @@ float runTemporalMemoryTest(UInt numColumns, UInt w,   int numSequences,
   vector<vector<SDR>> sequences;
   for (int i = 0; i < numSequences; i++) {
     vector<SDR> sequence;
-    SDR sdr({numColumns});
+    SDR sdr({numColumns}, {});
     for (int j = 0; j < numElements; j++) {
       const Real sparsity = w / static_cast<Real>(numColumns);
       sdr.randomize(sparsity, rng);
@@ -127,8 +127,8 @@ float runSpatialPoolerTest(
     );
   sp.setLocalAreaDensity(columnSparsity);
 
-  SDR input( sp.getInputDimensions() );
-  SDR columns( sp.getColumnDimensions() );
+  SDR input( sp.getInputDimensions(), {} );
+  SDR columns( sp.getColumnDimensions(), {} );
   cout << (float)timer.getElapsed() << " in " << label << ": initialize"  << endl;
 
   // Learn

--- a/src/test/unit/algorithms/ConnectionsTest.cpp
+++ b/src/test/unit/algorithms/ConnectionsTest.cpp
@@ -371,7 +371,7 @@ TEST(ConnectionsTest, testAdaptSynapses) {
   Connections con(numCells);
 
   vector<UInt> activeSegments;
-  SDR input({numInputs});
+  SDR input({numInputs}, {});
 
   UInt potentialArr[4][8] =  {{1, 1, 1, 1, 0, 0, 0, 0},
                               {1, 0, 0, 0, 1, 1, 0, 1},
@@ -714,7 +714,7 @@ TEST(ConnectionsTest, testCreateSynapseOverflow) {
 TEST(ConnectionsTest, testTimeseries) {
   Connections C( 1, .5, true );
   auto seg = C.createSegment(0);
-  SDR presyn({ 10u });
+  SDR presyn({ 10u }, {});
   for( UInt cell = 0; cell < presyn.size; cell++ ) {
     C.createSynapse(seg, cell, 0.5f );
   }

--- a/src/test/unit/algorithms/SDRClassifierTest.cpp
+++ b/src/test/unit/algorithms/SDRClassifierTest.cpp
@@ -47,7 +47,7 @@ namespace testing {
 TEST(SDRClassifierTest, ExampleUsageClassifier)
 {
   // Make a random SDR and associate it with the category B.
-  SDR inputData({ 1000u });
+  SDR inputData({ 1000u }, {});
       inputData.randomize( 0.02f );
   enum Category { A, B, C, D };
   Classifier clsr;
@@ -70,7 +70,7 @@ TEST(SDRClassifierTest, ExampleUsagePredictor)
   // Predict 1 and 2 time steps into the future.
 
   // Make a sequence of 4 random SDRs. Each SDR has 1000 bits and 2% sparsity.
-  vector<SDR> sequence( 4u, vector<UInt>{ 1000u } );
+  vector<SDR> sequence( 4u, SDR({ 1000u }, {}) );
   for( SDR & inputData : sequence ) {
       inputData.randomize( 0.02f );
   }
@@ -104,7 +104,7 @@ TEST(SDRClassifierTest, SingleValue) {
   Predictor c(steps, 0.1f);
 
   // Create a vector of input bit indices
-  SDR input1({10u}); input1.setSparse(SDR_sparse_t({ 1u, 5u, 9u }));
+  SDR input1({10u}, { 1u, 5u, 9u });
   vector<UInt> bucketIdxList{4u};
   for (UInt i = 0u; i < 10u; ++i) {
     c.learn( i, input1, bucketIdxList );
@@ -124,18 +124,15 @@ TEST(SDRClassifierTest, ComputeComplex) {
   Predictor c({1u}, 1.0f);
 
   // Create a input vector
-  SDR input1({ 20u });
-  input1.setSparse(SDR_sparse_t({ 1u, 5u, 9u }));
+  SDR input1({ 20u }, {1,5,9});
   vector<UInt> bucketIdxList1{ 4u };
 
   // Create a input vector
-  SDR input2({ 20u });
-  input2.setSparse(SDR_sparse_t({ 0u, 6u, 9u, 11u }));
+  SDR input2({ 20u }, {0,6,9,11});
   vector<UInt> bucketIdxList2{ 5u };
 
   // Create input vectors
-  SDR input3({ 20u });
-  input3.setSparse(SDR_sparse_t({ 6u, 9u }));
+  SDR input3({ 20u }, {6,9});
   vector<UInt> bucketIdxList3{ 5u };
   vector<UInt> bucketIdxList4{ 4u };
   vector<UInt> bucketIdxList5{ 4u };
@@ -171,13 +168,11 @@ TEST(SDRClassifierTest, MultipleCategories) {
   Classifier c(1.0f);
 
   // Create a input vectors
-  SDR input1({ 10 });
-  input1.setSparse(SDR_sparse_t({ 1u, 3u, 5u }));
+  SDR input1({ 10 }, {1,3,5});
   vector<UInt> bucketIdxList1{ 0u, 1u };
 
   // Create a input vectors
-  SDR input2({ 10 });
-  input2.setSparse(SDR_sparse_t({ 2u, 4u, 6u }));
+  SDR input2({ 10 }, {2,4,6});
   vector<UInt> bucketIdxList2{ 2u, 3u };
 
   // Train
@@ -207,7 +202,7 @@ TEST(SDRClassifierTest, SaveLoad) {
   Predictor c1(steps, 0.1f);
 
   // Train a Predictor with a few different things.
-  SDR A({ 100u }); A.randomize( 0.10f );
+  SDR A({ 100u }, {}); A.randomize( 0.10f );
   for(UInt i = 0; i < 10u; i++)
     { c1.learn(i, A, {4u}); }
   c1.reset();

--- a/src/test/unit/algorithms/SpatialPoolerTest.cpp
+++ b/src/test/unit/algorithms/SpatialPoolerTest.cpp
@@ -520,7 +520,7 @@ TEST(SpatialPoolerTest, testUpdateDutyCycles) {
   UInt numColumns = 5;
   setup(sp, numInputs, numColumns);
   vector<SynapseIdx> overlaps;
-  SDR active({numColumns});
+  SDR active({numColumns}, {});
 
   Real initOverlapArr1[] = {1, 1, 1, 1, 1};
   sp.setOverlapDutyCycles(initOverlapArr1);
@@ -797,7 +797,7 @@ TEST(SpatialPoolerTest, testAdaptSynapses) {
   UInt numInputs = 8;
   setup(sp, numInputs, numColumns);
 
-  SDR activeColumns({numColumns});
+  SDR activeColumns({numColumns}, {});
   vector<UInt> inputVector;
 
   UInt potentialArr1[4][8] = {{1, 1, 1, 1, 0, 0, 0, 0},
@@ -821,7 +821,7 @@ TEST(SpatialPoolerTest, testAdaptSynapses) {
       {0.070f, 0.000f, 0.000f, 0.000f, 0.000f, 0.000f, 0.178f, 0.000f}};
       //  -       -      -       -       -       -        -      -
 
-  SDR input1({8});
+  SDR input1({8}, {});
   input1.setDense(SDR_dense_t{1, 0, 0, 1, 1, 0, 1, 0});
   activeColumns.setSparse(SDR_sparse_t({ 0, 1, 2 }));
 
@@ -859,7 +859,7 @@ TEST(SpatialPoolerTest, testAdaptSynapses) {
       {0.170f, 0.000f, 0.000f, 0.000f, 0.000f, 0.000f, 0.380f, 0.000f}};
       //  -       -       -       -       -       -       -       -
 
-  SDR input2({8});
+  SDR input2({8}, {});
   input2.setDense(SDR_dense_t{1, 0, 0, 1, 1, 0, 1, 0});
   UInt activeColumnsArr2[3] = {0, 1, 2};
 
@@ -933,7 +933,7 @@ TEST(SpatialPoolerTest, testBumpUpWeakColumns) {
 TEST(SpatialPoolerTest, testUpdateDutyCyclesHelper) {
   SpatialPooler sp;
   vector<Real> dutyCycles;
-  SDR newValues({5});
+  SDR newValues({5}, {});
   UInt period;
 
   Real dutyCyclesArr1[] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
@@ -1077,7 +1077,7 @@ TEST(SpatialPoolerTest, testCalculateOverlap) {
 
   for (UInt i = 0; i < numTrials; i++) {
     vector<SynapseIdx> overlaps;
-    SDR input({numInputs});
+    SDR input({numInputs}, {});
     input.setDense(SDR_dense_t(inputs[i], inputs[i] + numInputs));
     sp.calculateOverlap_(input, overlaps);
     ASSERT_TRUE(check_vector_eq(trueOverlaps[i], overlaps));
@@ -2129,8 +2129,8 @@ TEST(SpatialPoolerTest, ExactOutput) {
   SDR gold_sdr;
   gold_sdr.load( gold_stream );
 
-  SDR inputs({ 1000 });
-  SDR columns({ 200 });
+  SDR inputs({ 1000 }, {});
+  SDR columns({ 200 }, {});
   SpatialPooler sp({inputs.dimensions}, {columns.dimensions},
                    /*potentialRadius*/ 99999,
                    /*potentialPct*/ 0.5f,

--- a/src/test/unit/algorithms/TemporalMemoryTest.cpp
+++ b/src/test/unit/algorithms/TemporalMemoryTest.cpp
@@ -71,9 +71,7 @@ TEST(TemporalMemoryTest, testCheckInputs_UnsortedColumns) {
       /*predictedSegmentDecrement*/ 0.0f,
       /*seed*/ 42);
 
-  SDR activeColumns({tm.getColumnDimensions()});
-  activeColumns.setSparse(SDR_sparse_t{1u, 3u, 2u, 4u});
-
+  SDR activeColumns({tm.getColumnDimensions()}, {1,3,2,4});
   EXPECT_NO_THROW(tm.compute(activeColumns, true));
 }
 
@@ -96,10 +94,8 @@ TEST(TemporalMemoryTest, ActivateCorrectlyPredictiveCells) {
       /*predictedSegmentDecrement*/ 0.0f,
       /*seed*/ 42);
 
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{1});
+  SDR previousActiveColumns({32}, {0});
+  SDR activeColumns({32}, {1});
   const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
   const vector<CellIdx> expectedActiveCells = {4};
 
@@ -135,8 +131,7 @@ TEST(TemporalMemoryTest, BurstUnpredictedColumns) {
       /*predictedSegmentDecrement*/ 0.0f,
       /*seed*/ 42);
 
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{0});
+  SDR activeColumns({32}, {0});
   const vector<CellIdx> burstingCells = {0, 1, 2, 3};
 
   tm.compute(activeColumns, true);
@@ -165,8 +160,7 @@ TEST(TemporalMemoryTest, ZeroActiveColumns) {
 
 
   // Make some cells predictive.
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0});
+  SDR previousActiveColumns({32}, {0});
   const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
   const vector<CellIdx> expectedActiveCells = {4};
 
@@ -181,8 +175,7 @@ TEST(TemporalMemoryTest, ZeroActiveColumns) {
   tm.activateDendrites();
   ASSERT_FALSE(tm.getPredictiveCells().getSum() == 0);
 
-  SDR empty({32});
-  empty.setSparse(SDR_sparse_t{});
+  SDR empty({32}, {});
   EXPECT_NO_THROW(tm.compute(empty, true)) << "failed with empty compute";
   EXPECT_TRUE(tm.getActiveCells().empty());
   EXPECT_TRUE(tm.getWinnerCells().empty());
@@ -208,10 +201,8 @@ TEST(TemporalMemoryTest, PredictedActiveCellsAreAlwaysWinners) {
       /*predictedSegmentDecrement*/ 0.0f,
       /*seed*/ 42);
 
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{1});
+  SDR previousActiveColumns({32}, {0});
+  SDR activeColumns({32}, {1});
   const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
   const vector<CellIdx> expectedWinnerCells = {4, 6};
 
@@ -249,8 +240,7 @@ TEST(TemporalMemoryTest, ChooseOneWinnerCellInBurstingColumn) {
       /*predictedSegmentDecrement*/ 0.0f,
       /*seed*/ 42);
 
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{0});
+  SDR activeColumns({32}, {0});
   const set<CellIdx> burstingCells = {0, 1, 2, 3};
 
   tm.compute(activeColumns, false);
@@ -278,11 +268,9 @@ TEST(TemporalMemoryTest, ReinforceCorrectlyActiveSegments) {
       /*predictedSegmentDecrement*/ 0.02f,
       /*seed*/ 42);
 
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0});  
+  SDR previousActiveColumns({32}, {0});
   const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{1});  
+  SDR activeColumns({32}, {1});
   const vector<CellIdx> activeCells = {5};
   const CellIdx activeCell = 5;
 
@@ -327,10 +315,8 @@ TEST(TemporalMemoryTest, ReinforceSelectedMatchingSegmentInBurstingColumn) {
       /*predictedSegmentDecrement*/ 0.0f,
       /*seed*/ 42);
 
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{1});
+  SDR previousActiveColumns({32}, {0});
+  SDR activeColumns({32}, {1});
   const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
   const vector<CellIdx> burstingCells = {4, 5, 6, 7};
 
@@ -384,10 +370,8 @@ TEST(TemporalMemoryTest,
       /*predictedSegmentDecrement*/ 0.0f,
       /*seed*/ 42);
 
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{1});
+  SDR previousActiveColumns({32}, {0});
+  SDR activeColumns({32}, {1});
   const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
   const vector<CellIdx> burstingCells = {4, 5, 6, 7};
 
@@ -437,10 +421,8 @@ TEST(TemporalMemoryTest, NoChangeToMatchingSegmentsInPredictedActiveColumn) {
       /*predictedSegmentDecrement*/ 0.0f,
       /*seed*/ 42);
 
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{1});
+  SDR previousActiveColumns({32}, {0});
+  SDR activeColumns({32}, {1});
   const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
   const vector<CellIdx> expectedActiveCells = {4};
   const vector<CellIdx> otherBurstingCells = {5, 6, 7};
@@ -492,10 +474,8 @@ TEST(TemporalMemoryTest, NoNewSegmentIfNotEnoughWinnerCells) {
       /*predictedSegmentDecrement*/ 0.0f,
       /*seed*/ 42);
 
-  SDR zeroColumns({32});
-  zeroColumns.setSparse(SDR_sparse_t{});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{1});
+  SDR zeroColumns({32}, {});
+  SDR activeColumns({32}, {1});
 
   tm.compute(zeroColumns, true);
   tm.compute(activeColumns, true);
@@ -521,10 +501,8 @@ TEST(TemporalMemoryTest, NewSegmentAddSynapsesToSubsetOfWinnerCells) {
       /*predictedSegmentDecrement*/ 0.0f,
       /*seed*/ 42);
 
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0,1,2});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{4});
+  SDR previousActiveColumns({32}, {0,1,2});
+  SDR activeColumns({32}, {4});
 
   tm.compute(previousActiveColumns);
 
@@ -566,10 +544,8 @@ TEST(TemporalMemoryTest, NewSegmentAddSynapsesToAllWinnerCells) {
       /*predictedSegmentDecrement*/ 0.0f,
       /*seed*/ 42);
 
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0,1,2});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{4});
+  SDR previousActiveColumns({32}, {0,1,2});
+  SDR activeColumns({32}, {4});
 
   tm.compute(previousActiveColumns);
 
@@ -615,10 +591,8 @@ TEST(TemporalMemoryTest, MatchingSegmentAddSynapsesToSubsetOfWinnerCells) {
       /*seed*/ 42);
 
   // Use 1 cell per column so that we have easy control over the winner cells.
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0,1,2,3});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{4});
+  SDR previousActiveColumns({32}, {0,1,2,3});
+  SDR activeColumns({32}, {4});
   const vector<CellIdx> prevWinnerCells = {0, 1, 2, 3};
 
   Segment matchingSegment = tm.createSegment(4);
@@ -662,10 +636,8 @@ TEST(TemporalMemoryTest, MatchingSegmentAddSynapsesToAllWinnerCells) {
 
   // Use 1 cell per column so that we have easy control over the winner cells.
   const vector<CellIdx> prevWinnerCells = {0, 1};
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0,1});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{4});
+  SDR previousActiveColumns({32}, {0,1});
+  SDR activeColumns({32}, {4});
 
   Segment matchingSegment = tm.createSegment(4);
   tm.connections.createSynapse(matchingSegment, 0, 0.5f);
@@ -706,10 +678,8 @@ TEST(TemporalMemoryTest, ActiveSegmentGrowSynapsesAccordingToPotentialOverlap) {
 
   // Use 1 cell per column so that we have easy control over the winner cells.
   const vector<CellIdx> prevWinnerCells = {0, 1, 2, 3, 4};
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0,1,2,3,4});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{5});
+  SDR previousActiveColumns({32}, {0,1,2,3,4});
+  SDR activeColumns({32}, {5});
 
   Segment activeSegment = tm.createSegment(5);
   tm.connections.createSynapse(activeSegment, 0, 0.5f);
@@ -750,10 +720,8 @@ TEST(TemporalMemoryTest, DestroyWeakSynapseOnWrongPrediction) {
       /*predictedSegmentDecrement*/ 0.02f,
       /*seed*/ 42);
 
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{2});
+  SDR previousActiveColumns({32}, {0});
+  SDR activeColumns({32}, {2});
   const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
   const CellIdx expectedActiveCell = 5;
 
@@ -789,10 +757,8 @@ TEST(TemporalMemoryTest, DestroyWeakSynapseOnActiveReinforce) {
       /*predictedSegmentDecrement*/ 0.02f,
       /*seed*/ 42);
 
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{1});
+  SDR previousActiveColumns({32}, {0});
+  SDR activeColumns({32}, {1});
   const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
   const CellIdx activeCell = 5;
 
@@ -832,10 +798,8 @@ TEST(TemporalMemoryTest, RecycleWeakestSynapseToMakeRoomForNewSynapse) {
 
   // Use 1 cell per column so that we have easy control over the winner cells.
   const vector<CellIdx> prevWinnerCells = {1, 2, 3};
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{1,2,3});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{4});
+  SDR previousActiveColumns({32}, {1,2,3});
+  SDR activeColumns({32}, {4});
 
   Segment matchingSegment = tm.createSegment(4);
 
@@ -892,14 +856,10 @@ TEST(TemporalMemoryTest,
       /*seed*/ 42,
       /*maxSegmentsPerCell*/ 2);
 
-  SDR previousActiveColumns1({32});
-  previousActiveColumns1.setSparse(SDR_sparse_t{0,1,2});
-  SDR previousActiveColumns2({32});
-  previousActiveColumns2.setSparse(SDR_sparse_t{3,4,5});
-  SDR previousActiveColumns3({32});
-  previousActiveColumns3.setSparse(SDR_sparse_t{6,7,8});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{9});
+  SDR previousActiveColumns1({32}, {0,1,2});
+  SDR previousActiveColumns2({32}, {3,4,5});
+  SDR previousActiveColumns3({32}, {6,7,8});
+  SDR activeColumns({32}, {9});
 
   tm.compute(previousActiveColumns1);
   tm.compute(activeColumns);
@@ -963,10 +923,8 @@ TEST(TemporalMemoryTest, DestroySegmentsWithTooFewSynapsesToBeMatching) {
       /*predictedSegmentDecrement*/ 0.02f,
       /*seed*/ 42);
 
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{2});
+  SDR previousActiveColumns({32}, {0});
+  SDR activeColumns({32}, {2});
   const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
   const CellIdx expectedActiveCell = 5;
 
@@ -1005,10 +963,8 @@ TEST(TemporalMemoryTest, PunishMatchingSegmentsInInactiveColumns) {
       /*predictedSegmentDecrement*/ 0.02f,
       /*seed*/ 42);
 
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{1});
+  SDR previousActiveColumns({32}, {0});
+  SDR activeColumns({32}, {1});
   const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
   const CellIdx previousInactiveCell = 81;
 
@@ -1071,10 +1027,8 @@ TEST(TemporalMemoryTest, AddSegmentToCellWithFewestSegments) {
         /*seed*/ seed);
 
     // enough for 4 winner cells
-    SDR previousActiveColumns({32});
-    previousActiveColumns.setSparse(SDR_sparse_t{1,2,3,4});
-    SDR activeColumns({32});
-    activeColumns.setSparse(SDR_sparse_t{0});
+    SDR previousActiveColumns({32}, {1,2,3,4});
+    SDR activeColumns({32}, {0});
     const vector<CellIdx> previousActiveCells = {4, 5, 6,7}; // (there are more)
     vector<CellIdx> nonmatchingCells = {0, 3};
     vector<CellIdx> activeCells = {0, 1, 2, 3};
@@ -1157,10 +1111,8 @@ TEST(TemporalMemoryTest, MaxNewSynapseCountOverflow) {
   tm.connections.createSynapse(segment, 6, 0.2f);
   tm.connections.createSynapse(segment, 7, 0.2f);
 
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0,1,3,4});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{2});
+  SDR previousActiveColumns({32}, {0,1,3,4});
+  SDR activeColumns({32}, {2});
 
   tm.compute(previousActiveColumns);
   tm.activateDendrites();
@@ -1193,10 +1145,8 @@ TEST(TemporalMemoryTest, ConnectionsNeverChangeWhenLearningDisabled) {
       /*predictedSegmentDecrement*/ 0.02f,
       /*seed*/ 42);
 
-  SDR previousActiveColumns({32});
-  previousActiveColumns.setSparse(SDR_sparse_t{0});
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{1 /*predicted*/, 2 /*bursting*/});
+  SDR previousActiveColumns({32}, {0});
+  SDR activeColumns({32}, { 1/*predicted*/, 2/*bursting*/});
   const vector<CellIdx> previousActiveCells = {0, 1, 2, 3};
   const CellIdx previousInactiveCell = 81;
   const vector<CellIdx> expectedActiveCells = {4};
@@ -1290,7 +1240,7 @@ TEST(TemporalMemoryTest, CreateSegmentDestroyOld) {
   tm.connections.createSynapse(segment1, 3, 0.5f);
 
   // Let some time pass.
-  SDR empty({32});
+  SDR empty({32}, {});
   tm.compute(empty);
   tm.compute(empty);
   tm.compute(empty);
@@ -1302,8 +1252,7 @@ TEST(TemporalMemoryTest, CreateSegmentDestroyOld) {
   tm.compute(empty);
 
   // Give the first segment some activity.
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{1,2,3});
+  SDR activeColumns({32}, {1,2,3});
 
   tm.compute(activeColumns);
   tm.activateDendrites();
@@ -1398,8 +1347,7 @@ TEST(TemporalMemoryTest, testCellsToColumns)
 
   auto correctDims = tm.getColumnDimensions();
   correctDims.push_back(tm.getCellsPerColumn());
-  SDR v1(correctDims);
-  v1.setSparse(SDR_sparse_t{4,5,8});
+  SDR v1(correctDims, {4,5,8});
   const SDR_sparse_t expected {1u, 2u};
 
   auto res = tm.cellsToColumns(v1);
@@ -1409,10 +1357,10 @@ TEST(TemporalMemoryTest, testCellsToColumns)
   res = tm.cellsToColumns(v1);
   EXPECT_TRUE(res.getSparse().empty());
 
-  SDR larger({10,10, 3});
+  SDR larger({10,10, 3}, {});
   EXPECT_ANY_THROW(tm.cellsToColumns(larger));
 
-  SDR wrongDims({3*3}); //matches numberOfCells, but dimensions are incorrect
+  SDR wrongDims({3*3}, {}); //matches numberOfCells, but dimensions are incorrect
   EXPECT_ANY_THROW(tm.cellsToColumns(wrongDims));
 };
 
@@ -1458,8 +1406,7 @@ void serializationTestPrepare(TemporalMemory &tm) {
   tm.connections.createSynapse(matchingSegment2, 2, 0.4f);
   tm.connections.createSynapse(matchingSegment2, 3, 0.4f);
 
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{0});
+  SDR activeColumns({32}, {0});
   tm.compute(activeColumns);
   tm.activateDendrites();
 
@@ -1477,8 +1424,7 @@ void serializationTestVerify(TemporalMemory &tm) {
   const vector<UInt> prevWinnerCells = tm.getWinnerCells();
   ASSERT_EQ(1ul, prevWinnerCells.size());
 
-  SDR activeColumns({32});
-  activeColumns.setSparse(SDR_sparse_t{1,2,3});
+  SDR activeColumns({32}, {1,2,3});
   tm.compute(activeColumns);
 
   // Verify the correct cells were activated.
@@ -1616,9 +1562,9 @@ TEST(TemporalMemoryTest, testSaveArLoadAr) {
  */
 TEST(TemporalMemoryTest, testExtraActive) {
 
-  SDR columns({120});
+  SDR columns({120}, {});
 
-  vector<SDR> pattern( 10, columns.dimensions );
+  vector<SDR> pattern( 10, SDR(columns.dimensions, {}) );
   for(auto i = 0u; i < pattern.size(); i++) {
     Random rng( i + 99u );             // Use deterministic seeds for unit tests.
     auto &sdr = pattern[i];
@@ -1644,8 +1590,8 @@ TEST(TemporalMemoryTest, testExtraActive) {
     /* extra */                        (UInt)(columns.size * 12u));
   auto tm_dimensions = tm.getColumnDimensions();
   tm_dimensions.push_back( tm.getCellsPerColumn() );
-  SDR extraActive( tm_dimensions );
-  SDR extraWinners( tm_dimensions );
+  SDR extraActive( tm_dimensions, {} );
+  SDR extraWinners(tm_dimensions, {} );
 
   // Look at the pattern.
   for(UInt trial = 0; trial < 20; trial++) {
@@ -1678,13 +1624,13 @@ TEST(TemporalMemoryTest, testExtraActive) {
   }
 }
 
+
 TEST(TemporalMemoryTest, testEquals) {
   TemporalMemory tm({10,10});
   auto tmCopy = tm;
   ASSERT_EQ(tm, tmCopy);
 
-  SDR data({tm.getColumnDimensions()});
-  data.setSparse(SDR_sparse_t{1,2,3,4,5,13,21,22,23,25,28,49,51,53,55,69});
+  SDR data({tm.getColumnDimensions()}, {1,2,3,4,5,13,21,22,23,25,28,49,51,53,55,69});
   tm.compute(data, true);
 
   ASSERT_NE(tm, tmCopy);
@@ -1692,13 +1638,14 @@ TEST(TemporalMemoryTest, testEquals) {
   ASSERT_EQ(tm, tmCopy);
 }
 
+
 TEST(TemporalMemoryTest, testIncorrectDefaultConstructor) {
   TemporalMemory tmFail; //default empty constructor is only used for deserialization
-  SDR data1({0});
+  SDR data1({0}, {});
   EXPECT_ANY_THROW(tmFail.compute(data1, true));
   
   TemporalMemory tmOk({32} /*column dims must always be specified*/);
-  SDR data2({tmOk.getColumnDimensions()});
+  SDR data2({tmOk.getColumnDimensions()}, {});
   EXPECT_NO_THROW(tmOk.compute(data2, true));
 }
 

--- a/src/test/unit/encoders/RandomDistributedScalarEncoderTest.cpp
+++ b/src/test/unit/encoders/RandomDistributedScalarEncoderTest.cpp
@@ -32,7 +32,7 @@ using namespace nupic::sdr;
 using namespace nupic::encoders;
 
 TEST(RDSE, testConstruct) {
-  SDR  A({ 100u, 100u, 3u });
+  SDR  A({ 100u, 100u, 3u }, {});
   RDSE_Parameters P;
   P.size       = A.size;
   P.sparsity   = 0.05f;
@@ -51,12 +51,12 @@ TEST(RDSE, testSerialize) {
   std::stringstream buf;
   R1.save( buf );
 
-  SDR A( R1.dimensions );
+  SDR A( R1.dimensions, {} );
   R1.encode( 44.4f, A );
 
   RDSE R2;
   R2.load( buf );
-  SDR B( R2.dimensions );
+  SDR B( R2.dimensions, {} );
   R2.encode( 44.4f, B );
 
   ASSERT_EQ( A, B );

--- a/src/test/unit/encoders/ScalarEncoderTest.cpp
+++ b/src/test/unit/encoders/ScalarEncoderTest.cpp
@@ -48,10 +48,9 @@ void doScalarValueCases(ScalarEncoder& e, std::vector<ScalarValueCase> cases)
 {
   for( auto c : cases )
   {
-    SDR expectedOutput( e.dimensions );
-    expectedOutput.setSparse( c.expectedOutput );
+    SDR expectedOutput( e.dimensions, c.expectedOutput );
 
-    SDR actualOutput( e.dimensions );
+    SDR actualOutput( e.dimensions, {} );
     e.encode( c.input, actualOutput );
 
     EXPECT_EQ( actualOutput, expectedOutput );
@@ -66,7 +65,7 @@ TEST(ScalarEncoder, testClippingInputs) {
   p.minimum    = 10;
   p.maximum    = 20;
 
-  SDR output({ 10 });
+  SDR output({ 10 }, {});
   {
     p.clipInput = false;
     ScalarEncoder e( p );
@@ -92,7 +91,7 @@ TEST(ScalarEncoder, ValidScalarInputs) {
   p.activeBits = 2;
   p.minimum    = 10;
   p.maximum    = 20;
-  SDR output({ 10 });
+  SDR output({ 10 }, {});
   ScalarEncoder e( p );
 
   EXPECT_ANY_THROW(e.encode( 9.9f, output));

--- a/src/test/unit/ntypes/ArrayTest.cpp
+++ b/src/test/unit/ntypes/ArrayTest.cpp
@@ -604,7 +604,7 @@ TEST_F(ArrayTest, testArrayBasefunctions) {
       // Only SDR has dimensions
       std::vector<UInt> d({ 10u, 10u });
       Dimensions dim(d);
-      sdr::SDR sdr(dim);
+      sdr::SDR sdr(dim, {});
       Array s(sdr); // makes a copy of sdr
       Dimensions dim_s(s.getSDR().dimensions);
       EXPECT_EQ(dim_s, dim);

--- a/src/test/unit/types/SdrTest.cpp
+++ b/src/test/unit/types/SdrTest.cpp
@@ -1006,4 +1006,17 @@ TEST(SdrTest, TestAssignmentOperator)
   EXPECT_EQ(a.dimensions, copy.dimensions);
 }
 
+/**
+ *  This test demonstrates a problem wher vectors would be treated as SDRs
+ *  in function arguments, which causes nasty hidden bugs. 
+ */
+TEST(SdrTest, testVectorIsNotSDR) {
+  const auto fooSDR = [](SDR arg1) {return;}; //function expects a SDR arg
+  SDR sdr({10});
+  vector<UInt> vector{10};
+
+  EXPECT_ANY_THROW(fooSDR(vector)) << "Function expects a SDR argument, but got vector. This should fail!";
+  EXPECT_NO_THROW(fooSDR(sdr));
+}
+
 } // End namespace testing

--- a/src/test/unit/types/SdrTest.cpp
+++ b/src/test/unit/types/SdrTest.cpp
@@ -735,16 +735,16 @@ TEST(SdrTest, TestSaveLoad) {
     ASSERT_TRUE(ret == 0) << "Failed to delete " << filename;
 
     // Check that all of the data is OK
-    ASSERT_TRUE( zero    == zero_2 );
-    ASSERT_TRUE( dense   == dense_2 );
-    ASSERT_TRUE( sparse  == sparse_2 );
-    ASSERT_TRUE( coord   == coord_2 );
+    ASSERT_EQ( zero, zero_2 );
+    ASSERT_EQ( dense, dense_2 );
+    ASSERT_EQ( sparse, sparse_2 );
+    ASSERT_EQ( coord, coord_2 );
 
     dense.setDense(SDR_dense_t({ 0, 1, 0, 0, 1, 0, 0, 0, 1 }));
     stringstream ss;
     dense.saveToStream_ar(ss, SerializableFormat::BINARY);
     dense_2.loadFromStream_ar(ss, SerializableFormat::BINARY);
-    ASSERT_TRUE( dense   == dense_2 );
+    ASSERT_EQ( dense,  dense_2 ) << "Binary data mismatch";
 
 }
 

--- a/src/test/unit/types/SdrTest.cpp
+++ b/src/test/unit/types/SdrTest.cpp
@@ -31,15 +31,15 @@ using namespace nupic::sdr;
 /* This also tests the size and dimensions are correct */
 TEST(SdrTest, TestConstructor) {
     // Test 0 dimensions
-    EXPECT_ANY_THROW( SDR( vector<UInt>(0) ));
+    EXPECT_ANY_THROW( SDR( vector<UInt>(0), {} ));
     // Test 0 size
-    EXPECT_NO_THROW( SDR({ 0 }) );
-    EXPECT_ANY_THROW( SDR({ 3, 2, 1, 0 }) );
-    EXPECT_NO_THROW(  SDR({ 3, 2, 1}) );
+    EXPECT_NO_THROW( SDR({ 0 }, {}) );
+    EXPECT_ANY_THROW( SDR({ 3, 2, 1, 0 }, {}) );
+    EXPECT_NO_THROW(  SDR({ 3, 2, 1}, {}) );
 
     // Test 1-D
     vector<UInt> b_dims = {3};
-    SDR b(b_dims);
+    SDR b(b_dims, {});
     ASSERT_EQ( b.size, 3ul );
     ASSERT_EQ( b.dimensions, b_dims );
     ASSERT_EQ( b.getCoordinates().size(), 1ul );
@@ -50,7 +50,7 @@ TEST(SdrTest, TestConstructor) {
 
     // Test 3-D
     vector<UInt> c_dims = {11u, 15u, 3u};
-    SDR c(c_dims);
+    SDR c(c_dims, {});
     ASSERT_EQ( c.size, 11u * 15u * 3u );
     ASSERT_EQ( c.dimensions, c_dims );
     ASSERT_EQ( c.getCoordinates().size(), 3ul );
@@ -71,13 +71,13 @@ TEST(SdrTest, testConstructorWithData) {
 
 
 TEST(SdrTest, TestEmptyPlaceholder) { //for NetworkAPI
-    EXPECT_NO_THROW( SDR({0})  );
-    EXPECT_EQ( SDR({0}).size, 0u  );
+    EXPECT_NO_THROW( SDR({0}, {})  );
+    EXPECT_EQ( SDR({0}, {}).size, 0u  );
 }
 
 TEST(SdrTest, TestConstructorCopy) {
     // Test data is copied.
-    SDR a({5});
+    SDR a({5}, {});
     a.setDense( SDR_dense_t({0, 1, 0, 0, 0}));
     SDR b(a);
     ASSERT_EQ( b.getSparse(),  vector<UInt>({1}) );
@@ -85,7 +85,7 @@ TEST(SdrTest, TestConstructorCopy) {
 }
 
 TEST(SdrTest, TestZero) {
-    SDR a({4, 4});
+    SDR a({4, 4}, {});
     a.setDense( vector<Byte>(16, 1) );
     a.zero();
     ASSERT_EQ( vector<Byte>(16, 0), a.getDense() );
@@ -98,7 +98,7 @@ TEST(SdrTest, TestZero) {
 TEST(SdrTest, TestSDR_Examples) {
     // Make an SDR with 9 values, arranged in a (3 x 3) grid.
     // "SDR" is an alias/typedef for SparseDistributedRepresentation.
-    SDR  X( {3, 3} );
+    SDR  X( {3, 3}, {} );
     SDR_dense_t data({
         0, 1, 0,
         0, 1, 0,
@@ -151,7 +151,7 @@ TEST(SdrTest, TestSDR_Examples) {
 }
 
 TEST(SdrTest, TestSetDenseVec) {
-    SDR a({11, 10, 4});
+    SDR a({11, 10, 4}, {});
     Byte *before = a.getDense().data();
     SDR_dense_t vec = vector<Byte>(440, 1);
     Byte *data = vec.data();
@@ -162,7 +162,7 @@ TEST(SdrTest, TestSetDenseVec) {
 }
 
 TEST(SdrTest, TestSetDenseByte) {
-    SDR a({11, 10, 4});
+    SDR a({11, 10, 4}, {});
     auto vec = vector<Byte>(a.size, 1);
     a.zero();
     a.setDense( (Byte*) vec.data());
@@ -172,15 +172,16 @@ TEST(SdrTest, TestSetDenseByte) {
 }
 
 TEST(SdrTest, TestSetDenseUInt) {
-    SDR a({11, 10, 4});
+    SDR a({11, 10, 4}, {});
     auto vec = vector<UInt>(a.size, 1);
     a.setDense( (UInt*) vec.data() );
     ASSERT_EQ( a.getDense(), vector<Byte>(a.size, 1) );
     ASSERT_NE( a.getDense().data(), (const Byte*) vec.data()); // true copy not a reference
 }
 
+
 TEST(SdrTest, TestSetDenseInplace) {
-    SDR a({10, 10});
+    SDR a({10, 10}, {});
     auto& a_data = a.getDense();
     ASSERT_EQ( a_data, vector<Byte>(100, 0) );
     a_data.assign( a.size, 1 );
@@ -192,7 +193,7 @@ TEST(SdrTest, TestSetDenseInplace) {
 }
 
 TEST(SdrTest, TestSetSparseVec) {
-    SDR a({11, 10, 4});
+    SDR a({11, 10, 4}, {});
     UInt *before = a.getSparse().data();
     auto vec = vector<UInt>(a.size, 1);
     UInt *data = vec.data();
@@ -205,7 +206,7 @@ TEST(SdrTest, TestSetSparseVec) {
 }
 
 TEST(SdrTest, TestSetSparsePtr) {
-    SDR a({11, 10, 4});
+    SDR a({11, 10, 4}, {});
     auto vec = vector<UInt>(a.size, 1);
     for(UInt i = 0; i < a.size; i++)
         vec[i] = i;
@@ -217,7 +218,7 @@ TEST(SdrTest, TestSetSparsePtr) {
 
 TEST(SdrTest, TestSetSparseInplace) {
     // Test both mutable & inplace methods at the same time, which is the intended use case.
-    SDR a({10, 10});
+    SDR a({10, 10}, {});
     a.zero();
     auto& a_data = a.getSparse();
     ASSERT_EQ( a_data, vector<UInt>(0) );
@@ -234,7 +235,7 @@ TEST(SdrTest, TestSetSparseInplace) {
 }
 
 TEST(SdrTest, TestSetCoordinates) {
-    SDR a({4, 1, 3});
+    SDR a({4, 1, 3}, {});
     void *before = a.getCoordinates().data();
     auto vec = vector<vector<UInt>>({
         { 0, 1, 2, 0 },
@@ -248,7 +249,7 @@ TEST(SdrTest, TestSetCoordinates) {
 }
 
 TEST(SdrTest, TestSetCoordinatesCopy) {
-    SDR a({ 3, 3 });
+    SDR a({ 3, 3 }, {});
     void *before = a.getCoordinates().data();
     auto vec = vector<vector<Real>>({
         { 0.0f, 1.0f, 2.0f },
@@ -263,7 +264,7 @@ TEST(SdrTest, TestSetCoordinatesCopy) {
 
 TEST(SdrTest, TestSetCoordinatesInplace) {
     // Test both mutable & inplace methods at the same time, which is the intended use case.
-    SDR a({10, 10});
+    SDR a({10, 10}, {});
     a.zero();
     auto& a_data = a.getCoordinates();
     ASSERT_EQ( a_data, vector<vector<UInt>>({{}, {}}) );
@@ -288,8 +289,8 @@ TEST(SdrTest, TestSetCoordinatesInplace) {
 }
 
 TEST(SdrTest, TestSetSDR) {
-    SDR a({5});
-    SDR b({5});
+    SDR a({5}, {});
+    SDR b({5}, {});
     // Test dense assignment works
     a.setDense(SDR_dense_t({1, 1, 1, 1, 1}));
     b.setSDR(a);
@@ -311,18 +312,18 @@ TEST(SdrTest, TestSetSDR) {
 
 TEST(SdrTest, TestGetDenseFromSparse) {
     // Test zeros
-    SDR z({4, 4});
+    SDR z({4, 4}, {});
     z.setSparse(SDR_sparse_t({}));
     ASSERT_EQ( z.getDense(), vector<Byte>(16, 0) );
 
     // Test ones
-    SDR nz({4, 4});
+    SDR nz({4, 4}, {});
     nz.setSparse(SDR_sparse_t(
         {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}));
     ASSERT_EQ( nz.getDense(), vector<Byte>(16, 1) );
 
     // Test 1-D
-    SDR d1({30});
+    SDR d1({30}, {});
     d1.setSparse(SDR_sparse_t({1, 29, 4, 5, 7}));
     vector<Byte> ans(30, 0);
     ans[1] = 1;
@@ -333,7 +334,7 @@ TEST(SdrTest, TestGetDenseFromSparse) {
     ASSERT_EQ( d1.getDense(), ans );
 
     // Test 3-D
-    SDR d3({10, 10, 10});
+    SDR d3({10, 10, 10}, {});
     d3.setSparse(SDR_sparse_t({0, 5, 50, 55, 500, 550, 555, 999}));
     vector<Byte> ans2(1000, 0);
     ans2[0]   = 1;
@@ -349,7 +350,7 @@ TEST(SdrTest, TestGetDenseFromSparse) {
 
 TEST(SdrTest, TestGetDenseFromCoordinates) {
     // Test simple 2-D
-    SDR a({3, 3});
+    SDR a({3, 3}, {});
     a.setCoordinates(SDR_coordinate_t({{1, 0, 2}, {2, 0, 2}}));
     vector<Byte> ans(9, 0);
     ans[0] = 1;
@@ -358,14 +359,15 @@ TEST(SdrTest, TestGetDenseFromCoordinates) {
     ASSERT_EQ( a.getDense(), ans );
 
     // Test zeros
-    SDR z({99, 1});
+    SDR z({99, 1}, {});
     z.setCoordinates(SDR_coordinate_t({{}, {}}));
     ASSERT_EQ( z.getDense(), vector<Byte>(99, 0) );
 }
 
 TEST(SdrTest, TestGetSparseFromDense) {
     // Test simple 2-D SDR.
-    SDR a({3, 3}); a.zero();
+    SDR a({3, 3}, {}); 
+    a.zero();
     auto dense = a.getDense();
     dense[5] = 1;
     dense[8] = 1;
@@ -380,7 +382,8 @@ TEST(SdrTest, TestGetSparseFromDense) {
 
 TEST(SdrTest, TestGetSparseFromCoordinates) {
     // Test simple 2-D SDR.
-    SDR a({3, 3}); a.zero();
+    SDR a({3, 3}, {}); 
+    a.zero();
     auto& index = a.getCoordinates();
     ASSERT_EQ( index.size(), 2ul );
     ASSERT_EQ( index[0].size(), 0ul );
@@ -406,7 +409,8 @@ TEST(SdrTest, TestGetSparseFromCoordinates) {
 
 TEST(SdrTest, TestGetCoordinatesFromSparse) {
     // Test simple 2-D SDR.
-    SDR a({3, 3}); a.zero();
+    SDR a({3, 3}, {}); 
+    a.zero();
     auto& index = a.getCoordinates();
     ASSERT_EQ( index.size(), 2ul );
     ASSERT_EQ( index[0].size(), 0ul );
@@ -423,7 +427,8 @@ TEST(SdrTest, TestGetCoordinatesFromSparse) {
 
 TEST(SdrTest, TestGetCoordinatesFromDense) {
     // Test simple 2-D SDR.
-    SDR a({3, 3}); a.zero();
+    SDR a({3, 3}, {}); 
+    a.zero();
     auto dense = a.getDense();
     dense[5] = 1;
     dense[8] = 1;
@@ -439,7 +444,7 @@ TEST(SdrTest, TestGetCoordinatesFromDense) {
 }
 
 TEST(SdrTest, TestAt) {
-    SDR a({3, 3});
+    SDR a({3, 3}, {});
     a.setSparse(SDR_sparse_t( {4, 5, 8} ));
     ASSERT_TRUE( a.at( {1, 1} ));
     ASSERT_TRUE( a.at( {1, 2} ));
@@ -453,7 +458,7 @@ TEST(SdrTest, TestAt) {
 }
 
 TEST(SdrTest, TestSumSparsity) {
-    SDR a({31, 17, 3});
+    SDR a({31, 17, 3}, {});
     auto& dense = a.getDense();
     for(UInt i = 0; i < a.size; i++) {
         ASSERT_EQ( i, a.getSum() );
@@ -467,18 +472,18 @@ TEST(SdrTest, TestSumSparsity) {
 
 TEST(SdrTest, TestPrint) {
     stringstream str;
-    SDR a({100});
+    SDR a({100}, {});
     str << a;
     // Use find so that trailing whitespace differences on windows/unix don't break it.
     ASSERT_NE( str.str().find( "SDR( 100 )" ), std::string::npos);
 
     stringstream str2;
-    SDR b({ 9, 8 });
+    SDR b({ 9, 8 }, {});
     str2 << b;
     ASSERT_NE( str2.str().find( "SDR( 9, 8 )" ), std::string::npos);
 
     stringstream str3;
-    SDR sdr3({ 3, 3 });
+    SDR sdr3({ 3, 3 }, {});
     sdr3.setDense(SDR_dense_t({ 0, 1, 0, 0, 1, 0, 0, 0, 1 }));
     str3 << sdr3;
     ASSERT_NE( str3.str().find( "SDR( 3, 3 ) 1, 4, 8" ), std::string::npos);
@@ -489,7 +494,7 @@ TEST(SdrTest, TestPrint) {
 }
 
 TEST(SdrTest, TestGetOverlap) {
-    SDR a({3, 3});
+    SDR a({3, 3}, {});
     a.setDense(SDR_dense_t({1, 1, 1, 1, 1, 1, 1, 1, 1}));
     SDR b(a);
     ASSERT_EQ( a.getOverlap( b ), 9ul );
@@ -503,7 +508,7 @@ TEST(SdrTest, TestGetOverlap) {
 
 TEST(SdrTest, TestRandomize) {
     // Test sparsity is OK
-    SDR a({1000});
+    SDR a({1000}, {});
     a.randomize( 0. );
     ASSERT_EQ( a.getSum(), 0ul );
     a.randomize( .25 );
@@ -539,7 +544,7 @@ TEST(SdrTest, TestRandomize) {
     ASSERT_TRUE( a != b);
     // Methodically test by running it many times and checking for an even
     // activation frequency at every bit.
-    SDR af_test({ 97 /* prime number */ });
+    SDR af_test({ 97 /* prime number */ }, {});
     UInt iterations = 10000;
     Real sparsity   = .25f;
     vector<Real> af( af_test.size, 0 );
@@ -556,7 +561,7 @@ TEST(SdrTest, TestRandomize) {
 }
 
 TEST(SdrTest, TestAddNoise) {
-    SDR a({1000});
+    SDR a({1000}, {});
     a.randomize( 0.10f );
     SDR b(a);
     SDR c(a);
@@ -603,9 +608,9 @@ TEST(SdrTest, TestAddNoise) {
 
 TEST(SdrTest, TestIntersectionExampleUsage) {
     // Setup 2 SDRs to hold the inputs.
-    SDR A({ 10 });
-    SDR B({ 10 });
-    SDR C({ 10 });
+    SDR A({ 10 }, {});
+    SDR B({ 10 }, {});
+    SDR C({ 10 }, {});
     A.setSparse(SDR_sparse_t{0, 1, 2, 3});
     B.setSparse(SDR_sparse_t      {2, 3, 4, 5});
     // Calculate the logical intersection
@@ -614,9 +619,9 @@ TEST(SdrTest, TestIntersectionExampleUsage) {
 }
 
 TEST(SdrTest, TestIntersection) {
-    SDR A({1000});
-    SDR B(A.dimensions);
-    SDR X(A.dimensions);
+    SDR A({1000}, {});
+    SDR B(A.dimensions, {});
+    SDR X(A.dimensions, {});
     A.randomize(.5);
     B.randomize(.5);
 
@@ -631,9 +636,9 @@ TEST(SdrTest, TestIntersection) {
 }
 
 TEST(SdrTest, TestConcatenationExampleUsage) {
-    SDR A({ 10 });
-    SDR B({ 10 });
-    SDR C({ 20 });
+    SDR A({ 10 }, {});
+    SDR B({ 10 }, {});
+    SDR C({ 20 }, {});
     A.setSparse(SDR_sparse_t{ 0, 1, 2 });
     B.setSparse(SDR_sparse_t{ 0, 1, 2 });
     C.concatenate( A, B );
@@ -641,10 +646,10 @@ TEST(SdrTest, TestConcatenationExampleUsage) {
 }
 
 TEST(SdrTest, TestConcatenation) {
-    SDR A({10});
-    SDR B({10});
-    SDR C({20});
-    SDR D({20});
+    SDR A({10}, {});
+    SDR B({10}, {});
+    SDR C({20}, {});
+    SDR D({20}, {});
     A.randomize( 0.30f );
     B.randomize( 0.70f );
     C.concatenate( A, B );
@@ -656,19 +661,19 @@ TEST(SdrTest, TestConcatenation) {
 TEST(SdrTest, TestEquality) {
     vector<SDR*> test_cases;
     // Test different dimensions
-    test_cases.push_back( new SDR({ 11 }));
-    test_cases.push_back( new SDR({ 1, 1 }));
-    test_cases.push_back( new SDR({ 1, 2, 3 }));
+    test_cases.push_back( new SDR({ 11 }, {}));
+    test_cases.push_back( new SDR({ 1, 1 }, {}));
+    test_cases.push_back( new SDR({ 1, 2, 3 }, {}));
     // Test different data
-    test_cases.push_back( new SDR({ 3, 3 }));
+    test_cases.push_back( new SDR({ 3, 3 }, {}));
     test_cases.back()->setDense(SDR_dense_t({0, 0, 1, 0, 1, 0, 1, 0, 0,}));
-    test_cases.push_back( new SDR({ 3, 3 }));
+    test_cases.push_back( new SDR({ 3, 3 }, {}));
     test_cases.back()->setDense(SDR_dense_t({0, 1, 0, 0, 1, 0, 0, 1, 0}));
-    test_cases.push_back( new SDR({ 3, 3 }));
+    test_cases.push_back( new SDR({ 3, 3 }, {}));
     test_cases.back()->setDense(SDR_dense_t({0, 1, 0, 0, 1, 0, 0, 0, 1}));
-    test_cases.push_back( new SDR({ 3, 3 }));
+    test_cases.push_back( new SDR({ 3, 3 }, {}));
     test_cases.back()->setSparse(SDR_sparse_t({0,}));
-    test_cases.push_back( new SDR({ 3, 3 }));
+    test_cases.push_back( new SDR({ 3, 3 }, {}));
     test_cases.back()->setSparse(SDR_sparse_t({3, 4, 6}));
 
     // Check that SDRs equal themselves
@@ -696,10 +701,10 @@ TEST(SdrTest, TestSaveLoad) {
     ofstream outfile;
     outfile.open(filename);
 
-    SDR zero({ 3, 3 });
-    SDR dense({ 3, 3 });
-    SDR sparse({ 3, 3 });
-    SDR coord({ 3, 3 });
+    SDR zero({ 3, 3 }, {});
+    SDR dense({ 3, 3 }, {});
+    SDR sparse({ 3, 3 }, {});
+    SDR coord({ 3, 3 }, {});
     {
       cereal::JSONOutputArchive json_out(outfile);
 
@@ -763,7 +768,7 @@ TEST(SdrTest, TestSaveLoad) {
 
 TEST(SdrTest, TestCallbacks) {
 
-    SDR A({ 10, 20 });
+    SDR A({ 10, 20 }, {});
     // Add and remove these callbacks a bunch of times, and then check they're
     // called the correct number of times.
     int count1 = 0;
@@ -838,7 +843,7 @@ TEST(SdrTest, TestCallbacks) {
 
 
 TEST(SdrReshapeTest, TestReshapeExamples) {
-    SDR     A(    { 4, 4 });
+    SDR     A(    { 4, 4 }, {});
     Reshape B( A, { 8, 2 });
     A.setCoordinates(SDR_coordinate_t({{1, 1, 2}, {0, 1, 2}}));
     auto coords = B.getCoordinates();
@@ -846,11 +851,11 @@ TEST(SdrReshapeTest, TestReshapeExamples) {
 }
 
 TEST(SdrReshapeTest, TestReshapeConstructor) {
-    SDR       A({ 11 });
+    SDR       A({ 11 }, {});
     Reshape   B( A );
     ASSERT_EQ( A.dimensions, B.dimensions );
     Reshape   C( A, { 11 });
-    SDR       D({ 5, 4, 3, 2, 1 });
+    SDR       D({ 5, 4, 3, 2, 1 }, {});
     Reshape   E( D, {1, 1, 1, 120, 1});
     Reshape   F( D, { 20, 6 });
     Reshape   X( (SDR&) F );
@@ -883,7 +888,7 @@ TEST(SdrReshapeTest, TestReshapeConstructor) {
 }
 
 TEST(SdrReshapeTest, TestReshapeDeconstructor) {
-    SDR     *A = new SDR({12});
+    SDR     *A = new SDR({12}, {});
     Reshape *B = new Reshape( *A );
     Reshape *C = new Reshape( *A, {3, 4} );
     Reshape *D = new Reshape( *C, {4, 3} );
@@ -910,21 +915,21 @@ TEST(SdrReshapeTest, TestReshapeDeconstructor) {
 }
 
 TEST(SdrReshapeTest, TestReshapeThrows) {
-    SDR A({10});
+    SDR A({10}, {});
     Reshape B(A, {2, 5});
     SDR *C = &B;
 
     ASSERT_ANY_THROW( C->setDense( SDR_dense_t( 10, 1 ) ));
     ASSERT_ANY_THROW( C->setCoordinates( SDR_coordinate_t({ {0}, {0} }) ));
     ASSERT_ANY_THROW( C->setSparse( SDR_sparse_t({ 0, 1, 2 }) ));
-    SDR X({10});
+    SDR X({10}, {});
     ASSERT_ANY_THROW( C->setSDR( X ));
     ASSERT_ANY_THROW( C->randomize(0.10f) );
     ASSERT_ANY_THROW( C->addNoise(0.10f) );
 }
 
 TEST(SdrReshapeTest, TestReshapeGetters) {
-    SDR A({ 2, 3 });
+    SDR A({ 2, 3 }, {});
     Reshape B( A, { 3, 2 });
     SDR *C = &B;
     // Test getting dense
@@ -958,25 +963,25 @@ TEST(SdrReshapeTest, TestSaveLoad) {
     outfile.open(filename);
 
     // Test zero value
-    SDR zero({ 3, 3 });
+    SDR zero({ 3, 3 }, {});
     Reshape z( zero );
     z.save( outfile );
 
     // Test dense data
-    SDR dense({ 3, 3 });
+    SDR dense({ 3, 3 }, {});
     Reshape d( dense );
     dense.setDense(SDR_dense_t({ 0, 1, 0, 0, 1, 0, 0, 0, 1 }));
     Serializable &ser = d;
     ser.save( outfile );
 
     // Test sparse data
-    SDR sparse({ 3, 3 });
+    SDR sparse({ 3, 3 }, {});
     Reshape f( sparse );
     sparse.setSparse(SDR_sparse_t({ 1, 4, 8 }));
     f.save( outfile );
 
     // Test coordinate data
-    SDR coord({ 3, 3 });
+    SDR coord({ 3, 3 }, {});
     Reshape x( coord );
     coord.setCoordinates(SDR_coordinate_t({
             { 0, 1, 2 },
@@ -1009,7 +1014,7 @@ TEST(SdrReshapeTest, TestSaveLoad) {
 
 TEST(SdrTest, TestAssignmentOperator) 
 {
-  SDR a({10, 10});
+  SDR a({10, 10}, {});
   a.setSparse<UInt>({1, 3, 5, 7});
   SDR copy; //notice the no dimensions
   ASSERT_EQ(copy.dimensions.size(), 0u);
@@ -1025,10 +1030,10 @@ TEST(SdrTest, TestAssignmentOperator)
  */
 TEST(SdrTest, testVectorIsNotSDR) {
   const auto fooSDR = [](SDR arg1) {return;}; //function expects a SDR arg
-  SDR sdr({10});
+  SDR sdr({10}, {});
   vector<UInt> vector{10};
 
-  EXPECT_ANY_THROW(fooSDR(vector)) << "Function expects a SDR argument, but got vector. This should fail!";
+//  EXPECT_ANY_THROW(fooSDR(vector)) << "Function expects a SDR argument, but got vector. This should fail!"; //OK, compile-time fail
   EXPECT_NO_THROW(fooSDR(sdr));
 }
 

--- a/src/test/unit/types/SdrTest.cpp
+++ b/src/test/unit/types/SdrTest.cpp
@@ -60,6 +60,16 @@ TEST(SdrTest, TestConstructor) {
     ASSERT_EQ( c.dimensions, vector<UInt>({11u, 15u, 3u}) );
 }
 
+
+TEST(SdrTest, testConstructorWithData) {
+  SDR_sparse_t initData = {1,3,5};
+  EXPECT_NO_THROW(const SDR sdrData({10}, initData));
+
+  const SDR sdrData({10}, initData);
+  ASSERT_EQ(sdrData.getSparse(), initData);
+}
+
+
 TEST(SdrTest, TestEmptyPlaceholder) { //for NetworkAPI
     EXPECT_NO_THROW( SDR({0})  );
     EXPECT_EQ( SDR({0}).size, 0u  );
@@ -89,12 +99,12 @@ TEST(SdrTest, TestSDR_Examples) {
     // Make an SDR with 9 values, arranged in a (3 x 3) grid.
     // "SDR" is an alias/typedef for SparseDistributedRepresentation.
     SDR  X( {3, 3} );
-    vector<Byte> data({
+    SDR_dense_t data({
         0, 1, 0,
         0, 1, 0,
         0, 0, 1 });
 
-    // These three statements are equivalent.
+    // These four statements are equivalent.
     X.setDense(SDR_dense_t({ 0, 1, 0,
                              0, 1, 0,
                              0, 0, 1 }));
@@ -103,6 +113,9 @@ TEST(SdrTest, TestSDR_Examples) {
     ASSERT_EQ( data, X.getDense() );
     X.setCoordinates(SDR_coordinate_t({{ 0, 1, 2,}, { 1, 1, 2 }}));
     ASSERT_EQ( data, X.getDense() );
+//    EXPECT_ANY_THROW(const SDR Xd({3,3}, data)); //data is dense, expected sparse
+    const SDR Xd({3,3}, SDR_sparse_t{1,4,8});
+    ASSERT_EQ(data, Xd.getDense());
 
     // Access data in any format, SDR will automatically convert data formats.
     ASSERT_EQ( X.getDense(),      SDR_dense_t({ 0, 1, 0, 0, 1, 0, 0, 0, 1 }) );
@@ -735,10 +748,10 @@ TEST(SdrTest, TestSaveLoad) {
     ASSERT_TRUE(ret == 0) << "Failed to delete " << filename;
 
     // Check that all of the data is OK
-    ASSERT_EQ( zero, zero_2 );
-    ASSERT_EQ( dense, dense_2 );
-    ASSERT_EQ( sparse, sparse_2 );
-    ASSERT_EQ( coord, coord_2 );
+    EXPECT_EQ( zero, zero_2 );
+    EXPECT_EQ( dense, dense_2 );
+    EXPECT_EQ( sparse, sparse_2 );
+    EXPECT_EQ( coord, coord_2 );
 
     dense.setDense(SDR_dense_t({ 0, 1, 0, 0, 1, 0, 0, 0, 1 }));
     stringstream ss;

--- a/src/test/unit/utils/SdrMetricsTest.cpp
+++ b/src/test/unit/utils/SdrMetricsTest.cpp
@@ -36,7 +36,7 @@ using namespace nupic::sdr;
  * Test that it creates & destroys, and that nothing crashes.
  */
 TEST(SdrMetricsTest, TestSparsityConstruct) {
-    SDR *A = new SDR({1});
+    SDR *A = new SDR({1}, {});
     Sparsity S( *A, 1000u );
     ASSERT_ANY_THROW( Sparsity S( *A, 0u ) ); // Period > 0!
     A->zero();
@@ -51,7 +51,7 @@ TEST(SdrMetricsTest, TestSparsityConstruct) {
 }
 
 TEST(SdrMetricsTest, TestSparsityExample) {
-    SDR A( { 1000u } );
+    SDR A( { 1000u }, {} );
     Sparsity B( A, 1000u );
     A.randomize( 0.01f );
     A.randomize( 0.15f );
@@ -68,7 +68,7 @@ TEST(SdrMetricsTest, TestSparsityExample) {
  * Verify that the initial 10 values of metric are OK.
  */
 TEST(SdrMetricsTest, TestSparsityShortTerm) {
-    SDR A({1});
+    SDR A({1}, {});
     Reshape B( A );
     Real period = 10u;
     Real alpha  = 1.0f / period;
@@ -139,7 +139,7 @@ TEST(SdrMetricsTest, TestSparsityLongTerm) {
     auto period     = 100u;
     auto iterations = 1000u;
 
-    SDR A({1000u});
+    SDR A({1000u}, {});
     Reshape B( A );
     Sparsity S( B, period );
 
@@ -168,7 +168,7 @@ TEST(SdrMetricsTest, TestSparsityPrint) {
     // Test passes if it does not crash.  The exact strings are checked by
     // python unit tests.
     std::stringstream ss;
-    SDR A({ 2000u });
+    SDR A({ 2000u }, {});
     Reshape B( A );
     Sparsity S( B, 10u );
 
@@ -189,7 +189,7 @@ TEST(SdrMetricsTest, TestSparsityPrint) {
  */
 TEST(SdrMetricsTest, TestAF_Construct) {
     // Test creating it.
-    SDR *A = new SDR({ 5 });
+    SDR *A = new SDR({ 5 }, {});
     Reshape *B = new Reshape( *A );
     ActivationFrequency F( *B, 100 );
     ASSERT_ANY_THROW( ActivationFrequency F( *A, 0u ) ); // Period > 0!
@@ -224,7 +224,7 @@ TEST(SdrMetricsTest, TestAF_Construct) {
  * Verify that the first few data points are ok.
  */
 TEST(SdrMetricsTest, TestAF_Example) {
-    SDR A({ 2u });
+    SDR A({ 2u }, {});
     Reshape B( A );
     ActivationFrequency F( B, 10u );
 
@@ -251,7 +251,7 @@ TEST(SdrMetricsTest, TestAF_Example) {
 TEST(SdrMetricsTest, TestAF_LongTerm) {
     const auto period  =  1000u;
     const auto runtime = 10000u;
-    SDR A({ 20u });
+    SDR A({ 20u }, {});
     Reshape B( A );
     ActivationFrequency F( B, period );
 
@@ -278,14 +278,14 @@ TEST(SdrMetricsTest, TestAF_Entropy) {
 
     // Extact tests:
     // Test all zeros.
-    SDR A({ size });
+    SDR A({ size }, {});
     Reshape Px( A );
     ActivationFrequency F( Px, period );
     A.zero();
     EXPECT_FLOAT_EQ( F.entropy(), 0.0f );
 
     // Test all ones.
-    SDR B({ size });
+    SDR B({ size }, {});
     ActivationFrequency G( B, period );
     B.randomize( 1.0f );
     EXPECT_FLOAT_EQ( G.entropy(), 0.0f );
@@ -296,13 +296,13 @@ TEST(SdrMetricsTest, TestAF_Entropy) {
     // so that the resulting SDR keeps the same sparsity.  Progresively disable
     // more cells and verify that the entropy monotonically decreases.  Finally
     // verify 0% entropy when all cells are disabled.
-    SDR C({ size });
+    SDR C({ size }, {});
     ActivationFrequency H( C, period );
     auto last_entropy = -1.0f;
     const UInt incr = size / 10u; // NOTE: This MUST divide perfectly, with no remainder!
     for(auto nbits_disabled = 0u; nbits_disabled <= size; nbits_disabled += incr) {
         for(auto i = 0u; i < runtime; i++) {
-            SDR scratch({size});
+            SDR scratch({size}, {});
             scratch.randomize( 0.05f );
             // Freeze bits, such that nbits remain alive.
             for(auto z = 0u; z < nbits_disabled; z++)
@@ -330,7 +330,7 @@ TEST(SdrMetricsTest, TestAF_Print) {
     std::stringstream ss;
     const auto period  =  100u;
     const auto runtime = 1000u;
-    SDR A({ 2000u });
+    SDR A({ 2000u }, {});
     ActivationFrequency F( A, period );
 
     vector<Real> sparsity{ 0.0f, 0.02f, 0.05f, 0.50f, 0.0f };
@@ -344,7 +344,7 @@ TEST(SdrMetricsTest, TestAF_Print) {
 }
 
 TEST(SdrMetricsTest, TestOverlap_Construct) {
-    SDR *A = new SDR({ 1000u });
+    SDR *A = new SDR({ 1000u }, {});
     Overlap V( *A, 100u );
     ASSERT_ANY_THROW( new Overlap( *A, 0 ) ); // Period > 0!
     // Check that it doesn't crash, when uninitialized.
@@ -381,7 +381,7 @@ TEST(SdrMetricsTest, TestOverlap_Construct) {
 }
 
 TEST(SdrMetricsTest, TestOverlap_Example) {
-    SDR A({ 10000u });
+    SDR A({ 10000u }, {});
     Reshape Px( A );
     Overlap B( Px, 1000u );
     A.randomize( 0.05f );
@@ -396,7 +396,7 @@ TEST(SdrMetricsTest, TestOverlap_Example) {
 }
 
 TEST(SdrMetricsTest, TestOverlap_ShortTerm) {
-    SDR     A({ 1000u });
+    SDR     A({ 1000u }, {});
     Reshape Px( A );
     Overlap V( Px, 10u );
 
@@ -430,7 +430,7 @@ TEST(SdrMetricsTest, TestOverlap_ShortTerm) {
 TEST(SdrMetricsTest, TestOverlap_LongTerm) {
     const auto runtime = 1000u;
     const auto period  =  100u;
-    SDR A({ 500u });
+    SDR A({ 500u }, {});
     Reshape Px( A );
     Overlap V( Px, period );
     A.randomize( 0.45f );
@@ -464,7 +464,7 @@ TEST(SdrMetricsTest, TestOverlap_Print) {
     // Test passes if it does not crash.  The exact strings are checked by
     // python unit tests.
     stringstream ss;
-    SDR A({ 2000u });
+    SDR A({ 2000u }, {});
     Reshape Px( A );
     Overlap V( Px, 100u );
     A.randomize( 0.02f );
@@ -488,7 +488,7 @@ TEST(SdrMetricsTest, TestOverlap_Print) {
  */
 TEST(SdrMetricsTest, TestAllMetrics_Construct) {
     // Test that it constructs.
-    SDR *A = new SDR({ 100u });
+    SDR *A = new SDR({ 100u }, {});
     Metrics M( *A, 10u );
 
     A->randomize( 0.05f );
@@ -501,7 +501,7 @@ TEST(SdrMetricsTest, TestAllMetrics_Construct) {
     devnull << M;
 
     // Test delete Metric and keep using SDR.
-    A = new SDR({ 100u });
+    A = new SDR({ 100u }, {});
     Metrics *B = new Metrics( *A, 99u );
     Metrics *C = new Metrics( *A, 98u );
     A->randomize( 0.20f );
@@ -528,7 +528,7 @@ TEST(SdrMetricsTest, TestAllMetrics_Print) {
     // Test passes if it does not crash.  The exact strings are checked by
     // python unit tests.
   stringstream ss;
-    SDR A({ 4097u });
+    SDR A({ 4097u }, {});
     Reshape Px( A );
     Metrics M( Px, 100u );
 
@@ -552,17 +552,17 @@ TEST(SdrMetricsTest, TestAddData) {
     Metrics M( {10u, 5u, 2u}, 100u );
 
     // Check error checking
-    SDR badDims({2u, 5u, 10u});
+    SDR badDims({2u, 5u, 10u}, {});
     ASSERT_ANY_THROW( M.addData(badDims) );
     // Check that addData() only works when using the correct initializer.
-    SDR A({100u});
+    SDR A({100u}, {});
     Metrics otherInit(A, 100u);
     ASSERT_ANY_THROW( otherInit.addData(A) );
     SDR B(A);
     ASSERT_ANY_THROW( otherInit.addData(B) );
 
     // Sanity check that data is used, not discarded.
-    SDR C( M.dimensions );
+    SDR C( M.dimensions, {} );
     C.randomize( 0.20f );
     for(auto i = 0u; i < 10u; i++) {
         C.addNoise( 0.5f );


### PR DESCRIPTION
- [x] adds a reproducible test for "vector auto-casts to SDR"
  - which causes confusing bugs, as all compiles fine, but SDR is filled with dimensions/or other vector data. 
- [x] we want to keep copy constructor, and assignment operator, 
- [x] thus need to change SDR's constructor from SDR(vector), to SDR(vector, vector)
  - [x] lot of code, esp tests had to be updated
  - new code is easy to write
- [x] adds new feature to construct a cost SDR filled with data.

Fixes #416 