### PR TITLE
ScalarEncoder & RDSE display scripts allow Categories.

### DIFF
--- a/bindings/py/cpp_src/bindings/encoders/py_RDSE.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_RDSE.cpp
@@ -36,8 +36,8 @@ R"(Parameters for the RandomDistributedScalarEncoder (RDSE)
 Members "activeBits" & "sparsity" are mutually exclusive, specify exactly one
 of them.
 
-Members "radius" & "resolution" are mutually exclusive, specify exactly one of
-them.)");
+Members "radius", "resolution", and "category" are mutually exclusive, specify
+exactly one of them.)");
 
         py_RDSE_args.def(py::init<>());
 
@@ -61,6 +61,11 @@ the input.)");
         py_RDSE_args.def_readwrite("resolution", &RDSE_Parameters::resolution,
 R"(Two inputs separated by greater than, or equal to the resolution are
 guaranteed to have different representations.)");
+
+        py_RDSE_args.def_readwrite("category", &RDSE_Parameters::category,
+R"(Member "category" means that the inputs are enumerated categories.
+If true then this encoder will only encode unsigned integers, and all
+inputs will have unique / non-overlapping representations.)");
 
         py_RDSE_args.def_readwrite("seed", &RDSE_Parameters::seed,
 R"(Member "seed" forces different encoders to produce different outputs, even if

--- a/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
@@ -37,9 +37,10 @@ namespace nupic_ext
     py::class_<ScalarEncoderParameters> py_ScalarEncParams(m, "ScalarEncoderParameters",
         R"(
 
-The following three (3) members define the total number of bits in the output:
+The following four (4) members define the total number of bits in the output:
      size,
      radius,
+     category,
      resolution.
 
 These are mutually exclusive and only one of them should be non-zero when
@@ -64,10 +65,16 @@ R"(This controls what happens near the edges of the input range.
 
 If true, then the minimum & maximum input values are adjacent and the first and
 last bits of the output SDR are also adjacent.  The contiguous block of 1's
-wraps around the end back to the begining.
+wraps around the end back to the beginning.
 
 If false, then minimum & maximum input values are the endpoints of the input
 range, are not adjacent, and activity does not wrap around.)");
+
+    py_ScalarEncParams.def_readwrite("category", &ScalarEncoderParameters::category,
+R"(This means that the inputs are enumerated categories.
+
+If true then this encoder will only encode unsigned integers, and all inputs
+will have unique / non-overlapping representations.)");
 
     py_ScalarEncParams.def_readwrite("activeBits", &ScalarEncoderParameters::activeBits,
 R"(This is the number of true bits in the encoded output SDR. The output

--- a/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/py_ScalarEncoder.cpp
@@ -72,7 +72,6 @@ range, are not adjacent, and activity does not wrap around.)");
 
     py_ScalarEncParams.def_readwrite("category", &ScalarEncoderParameters::category,
 R"(This means that the inputs are enumerated categories.
-
 If true then this encoder will only encode unsigned integers, and all inputs
 will have unique / non-overlapping representations.)");
 

--- a/py/src/nupic/encoders/rdse.py
+++ b/py/src/nupic/encoders/rdse.py
@@ -58,6 +58,9 @@ if __name__ == '__main__':
                         help=RDSE_Parameters.size.__doc__)
     parser.add_argument('--sparsity', type=float, default=0,
                         help=RDSE_Parameters.sparsity.__doc__)
+    parser.add_argument('--category', action='store_true',
+                        help="Assume the inputs are enumerated categories.\n" +
+                             "Only encodes integers, forces radius=1.")
     args = parser.parse_args()
 
     #
@@ -69,6 +72,14 @@ if __name__ == '__main__':
     parameters.resolution = args.resolution
     parameters.size       = args.size
     parameters.sparsity   = args.sparsity
+
+    if args.category:
+        if parameters.radius == 0:
+            parameters.radius = 1
+            print("Category encoder requested, setting radius to 1.")
+        elif parameters.radius != 1:
+            print("Category encoder requested, but radius is not equal to 1!")
+            exit()
 
     # Try initializing the encoder.
     try:
@@ -83,9 +94,12 @@ if __name__ == '__main__':
     #
     # Run the encoder and measure some statistics about its output.
     #
+    if args.category:
+        n_samples = int(args.maximum - args.minimum + 1)
+    else:
+        n_samples = (args.maximum - args.minimum) / enc.parameters.resolution
+        n_samples = int(round( 5 * n_samples ))
     sdrs = []
-    n_samples = (args.maximum - args.minimum) / enc.parameters.resolution
-    n_samples = int(round( 5 * n_samples ))
     for i in np.linspace(args.minimum, args.maximum, n_samples):
       sdrs.append( enc.encode( i ) )
 

--- a/py/src/nupic/encoders/rdse.py
+++ b/py/src/nupic/encoders/rdse.py
@@ -47,9 +47,9 @@ if __name__ == '__main__':
     parser.add_argument('--activeBits', type=int, default=0,
                         help=RDSE_Parameters.activeBits.__doc__)
     parser.add_argument('--minimum', type=float, required=True,
-                        help="TODO")
+                        help="Boundary of input range to display.")
     parser.add_argument('--maximum', type=float, required=True,
-                        help="TODO")
+                        help="Boundary of input range to display.")
     parser.add_argument('--radius', type=float, default=0,
                         help=RDSE_Parameters.radius.__doc__)
     parser.add_argument('--resolution', type=float, default=0,
@@ -59,8 +59,9 @@ if __name__ == '__main__':
     parser.add_argument('--sparsity', type=float, default=0,
                         help=RDSE_Parameters.sparsity.__doc__)
     parser.add_argument('--category', action='store_true',
-                        help="Assume the inputs are enumerated categories.\n" +
-                             "Only encodes integers, forces radius=1.")
+                        help=RDSE_Parameters.category.__doc__)
+    parser.add_argument('--seed', type=int, default=0,
+                        help=RDSE_Parameters.seed.__doc__)
     args = parser.parse_args()
 
     #
@@ -72,14 +73,8 @@ if __name__ == '__main__':
     parameters.resolution = args.resolution
     parameters.size       = args.size
     parameters.sparsity   = args.sparsity
-
-    if args.category:
-        if parameters.radius == 0:
-            parameters.radius = 1
-            print("Category encoder requested, setting radius to 1.")
-        elif parameters.radius != 1:
-            print("Category encoder requested, but radius is not equal to 1!")
-            exit()
+    parameters.category   = args.category
+    parameters.seed       = args.seed
 
     # Try initializing the encoder.
     try:

--- a/py/src/nupic/encoders/scalar_encoder.py
+++ b/py/src/nupic/encoders/scalar_encoder.py
@@ -59,6 +59,9 @@ if __name__ == '__main__':
                         help=ScalarEncoderParameters.size.__doc__)
     parser.add_argument('--sparsity', type=float, default=0,
                         help=ScalarEncoderParameters.sparsity.__doc__)
+    parser.add_argument('--category', action='store_true',
+                        help="Assume the inputs are enumerated categories.\n" +
+                             "Only encodes integers, forces radius=1.")
     args = parser.parse_args()
 
     #
@@ -75,6 +78,14 @@ if __name__ == '__main__':
     parameters.size       = args.size
     parameters.sparsity   = args.sparsity
 
+    if args.category:
+        if parameters.radius == 0:
+            parameters.radius = 1
+            print("Category encoder requested, setting radius to 1.")
+        elif parameters.radius != 1:
+            print("Category encoder requested, but radius is not equal to 1!")
+            exit()
+
     # Try initializing the encoder.
     try:
         enc = ScalarEncoder( parameters )
@@ -88,9 +99,12 @@ if __name__ == '__main__':
     #
     # Run the encoder and measure some statistics about its output.
     #
+    if args.category:
+        n_samples = int(enc.parameters.maximum - enc.parameters.minimum + 1)
+    else:
+        n_samples = (enc.parameters.maximum - enc.parameters.minimum) / enc.parameters.resolution
+        n_samples = int(round( 5 * n_samples ))
     sdrs = []
-    n_samples = (enc.parameters.maximum - enc.parameters.minimum) / enc.parameters.resolution
-    n_samples = int(round( 5 * n_samples ))
     for i in np.linspace(enc.parameters.minimum, enc.parameters.maximum, n_samples):
       sdrs.append( enc.encode( i ) )
 

--- a/py/src/nupic/encoders/scalar_encoder.py
+++ b/py/src/nupic/encoders/scalar_encoder.py
@@ -45,9 +45,9 @@ if __name__ == '__main__':
                                         ScalarEncoderParameters.__doc__))
     parser.add_argument('--activeBits', type=int, default=0,
                         help=ScalarEncoderParameters.activeBits.__doc__)
-    parser.add_argument('--minimum', type=float, required=True,
+    parser.add_argument('--minimum', type=float, default=0,
                         help=ScalarEncoderParameters.minimum.__doc__)
-    parser.add_argument('--maximum', type=float, required=True,
+    parser.add_argument('--maximum', type=float, default=0,
                         help=ScalarEncoderParameters.maximum.__doc__)
     parser.add_argument('--periodic', action='store_true', default=False,
                         help=ScalarEncoderParameters.periodic.__doc__)
@@ -60,8 +60,7 @@ if __name__ == '__main__':
     parser.add_argument('--sparsity', type=float, default=0,
                         help=ScalarEncoderParameters.sparsity.__doc__)
     parser.add_argument('--category', action='store_true',
-                        help="Assume the inputs are enumerated categories.\n" +
-                             "Only encodes integers, forces radius=1.")
+                        help=ScalarEncoderParameters.category.__doc__)
     args = parser.parse_args()
 
     #
@@ -77,14 +76,7 @@ if __name__ == '__main__':
     parameters.resolution = args.resolution
     parameters.size       = args.size
     parameters.sparsity   = args.sparsity
-
-    if args.category:
-        if parameters.radius == 0:
-            parameters.radius = 1
-            print("Category encoder requested, setting radius to 1.")
-        elif parameters.radius != 1:
-            print("Category encoder requested, but radius is not equal to 1!")
-            exit()
+    parameters.category   = args.category
 
     # Try initializing the encoder.
     try:

--- a/src/nupic/encoders/RandomDistributedScalarEncoder.hpp
+++ b/src/nupic/encoders/RandomDistributedScalarEncoder.hpp
@@ -35,8 +35,8 @@ namespace encoders {
  * Members "activeBits" & "sparsity" are mutually exclusive, specify exactly one
  * of them.
  *
- * Members "radius" & "resolution" are mutually exclusive, specify exactly one of
- * them.
+ * Members "radius", "resolution", & "category" are mutually exclusive, specify
+ * exactly one of them.
  */
 struct RDSE_Parameters
 {
@@ -70,6 +70,13 @@ struct RDSE_Parameters
    * resolution are guaranteed to have different representations.
    */
   Real resolution = 0.0f;
+
+  /**
+   * Member "category" means that the inputs are enumerated categories.
+   * If true then this encoder will only encode unsigned integers, and all
+   * inputs will have unique / non-overlapping representations.
+   */
+  bool category = false;
 
   /**
    * Member "seed" forces different encoders to produce different outputs, even

--- a/src/nupic/encoders/ScalarEncoder.hpp
+++ b/src/nupic/encoders/ScalarEncoder.hpp
@@ -35,6 +35,16 @@
 namespace nupic {
 namespace encoders {
 
+  /**
+   * These four (4) members define the total number of bits in the output:
+   *      size,
+   *      radius,
+   *      category,
+   *      resolution.
+   *
+   * These are mutually exclusive and only one of them should be non-zero when
+   * constructing the encoder.
+   */
   struct ScalarEncoderParameters
   {
     /**
@@ -58,12 +68,19 @@ namespace encoders {
      *
      * If true, then the minimum & maximum input values are the same and the
      * first and last bits of the output SDR are adjacent.  The contiguous
-     * block of 1's wraps around the end back to the begining.
+     * block of 1's wraps around the end back to the beginning.
      *
      * If false, then minimum & maximum input values are the endpoints of the
      * input range, are not adjacent, and activity does not wrap around.
      */
     bool periodic = false;
+
+    /**
+     * Member "category" means that the inputs are enumerated categories.
+     * If true then this encoder will only encode unsigned integers, and all
+     * inputs will have unique / non-overlapping representations.
+     */
+    bool category = false;
 
     /**
      * Member "activeBits" is the number of true bits in the encoded output SDR.
@@ -77,16 +94,6 @@ namespace encoders {
      * Specify only one of: activeBits or sparsity.
      */
     Real sparsity = 0.0f;
-
-    /**
-     * These three (3) members define the total number of bits in the output:
-     *      size,
-     *      radius,
-     *      resolution.
-     *
-     * These are mutually exclusive and only one of them should be non-zero when
-     * constructing the encoder.
-     */
 
     /**
      * Member "size" is the total number of bits in the encoded output SDR.
@@ -123,8 +130,8 @@ namespace encoders {
   {
   public:
     ScalarEncoder() {};
-    ScalarEncoder( ScalarEncoderParameters &parameters );
-    void initialize( ScalarEncoderParameters &parameters );
+    ScalarEncoder( const ScalarEncoderParameters &parameters );
+    void initialize( const ScalarEncoderParameters &parameters );
 
     const ScalarEncoderParameters &parameters = args_;
 


### PR DESCRIPTION
For issue #258.

New flag "--category" for the programs:
- nupic.encoders.scalar_encoder
- nupic.encoders.rdse

With this flag the program will plot only integer values and
checks for / supplies the correct parameters for category encoding.