### PR TITLE
Encoder viewing programs minor fix

### DIFF
--- a/py/src/nupic/encoders/rdse.py
+++ b/py/src/nupic/encoders/rdse.py
@@ -93,7 +93,8 @@ if __name__ == '__main__':
         n_samples = int(args.maximum - args.minimum + 1)
     else:
         n_samples = (args.maximum - args.minimum) / enc.parameters.resolution
-        n_samples = int(round( 5 * n_samples ))
+        oversample = 2 # Use more samples than needed to avoid aliasing & artifacts.
+        n_samples  = int(round( oversample * n_samples ))
     sdrs = []
     for i in np.linspace(args.minimum, args.maximum, n_samples):
       sdrs.append( enc.encode( i ) )

--- a/py/src/nupic/encoders/scalar_encoder.py
+++ b/py/src/nupic/encoders/scalar_encoder.py
@@ -95,7 +95,8 @@ if __name__ == '__main__':
         n_samples = int(enc.parameters.maximum - enc.parameters.minimum + 1)
     else:
         n_samples = (enc.parameters.maximum - enc.parameters.minimum) / enc.parameters.resolution
-        n_samples = int(round( 5 * n_samples ))
+        oversample = 2 # Use more samples than needed to avoid aliasing & artifacts.
+        n_samples  = int(round( oversample * n_samples ))
     sdrs = []
     for i in np.linspace(enc.parameters.minimum, enc.parameters.maximum, n_samples):
       sdrs.append( enc.encode( i ) )


### PR DESCRIPTION
From https://github.com/htm-community/nupic.cpp/pull/448#discussion_r281889515

Add comments explaining about oversampling the inputs.
Use more samples than needed to avoid aliasing & artifacts.

Reduced the oversample factor from 5 to 2.  Before with 5 all of the
diagrams were stretched out along the X axis, excessively so.  Now they
are more compact, without losing any fidelity.