### PR TITLE
Date Time Encoder

### DIFF
--- a/py/src/nupic/encoders/date.py
+++ b/py/src/nupic/encoders/date.py
@@ -61,6 +61,7 @@ class DateEncoder:
         - (tuple) dayOfWeek[0] = width; dayOfWeek[1] = radius
 
     Argument weekend: (int) Is a weekend or not. A block of bits either 0s or 1s.
+    Note: the implementation treats "weekend" as starting Fri 6pm, till Sun midnight. 
 
         - (int) width of attribute
         - TODO remove and replace by customDays=(width, ["Saturday", "Sunday"]) ?

--- a/py/src/nupic/encoders/date.py
+++ b/py/src/nupic/encoders/date.py
@@ -63,6 +63,7 @@ class DateEncoder:
     Argument weekend: (int) Is a weekend or not. A block of bits either 0s or 1s.
 
         - (int) width of attribute
+        - TODO remove and replace by customDays=(width, ["Saturday", "Sunday"]) ?
 
     Argument holiday: (int) Is a holiday or not, boolean: 0, 1
 

--- a/py/src/nupic/encoders/date.py
+++ b/py/src/nupic/encoders/date.py
@@ -1,0 +1,315 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2013, Numenta, Inc.
+#               2019, David McDougall
+#
+# Unless you have an agreement with Numenta, Inc., for a separate license for
+# this software code, the following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+import datetime
+
+import numpy
+import math
+
+from nupic.encoders.scalar_encoder import ScalarEncoder, ScalarEncoderParameters
+from nupic.bindings.sdr import SDR
+
+
+class DateEncoder:
+  """
+  A date encoder encodes a time and date.  The input to a date encoder is a
+  datetime.datetime object. The output is the concatenation of several sub-
+  encodings, each of which encodes a different aspect of the date. Which sub-
+  encodings are present, and details of those sub-encodings, are specified in
+  the DateEncoder constructor.
+  """
+  def __init__(self,
+          season=0,
+          dayOfWeek=0,
+          weekend=0,
+          holiday=0,
+          timeOfDay=0,
+          customDays=0,
+          holidays=((12, 25),)):
+    """
+    Each parameter describes one attribute to encode. By default, the attribute
+    is not encoded.
+
+    Argument season: (int | tuple) Season of the year, where units = day.
+
+        - (int) width of attribute; default radius = 91.5 days (1 season)
+        - (tuple)  season[0] = width; season[1] = radius
+
+    Argument dayOfWeek: (int | tuple) Day of week, where monday = 0, units = 1 day.
+
+        - (int) width of attribute; default radius = 1 day
+        - (tuple) dayOfWeek[0] = width; dayOfWeek[1] = radius
+
+    Argument weekend: (int) Is a weekend or not. A block of bits either 0s or 1s.
+
+        - (int) width of attribute
+
+    Argument holiday: (int) Is a holiday or not, boolean: 0, 1
+
+        - (int) width of attribute
+
+    Argument timeOfday: (int | tuple) Time of day, where midnight = 0, units = hour.
+
+        - (int) width of attribute: default radius = 4 hours
+        - (tuple) timeOfDay[0] = width; timeOfDay[1] = radius
+
+    Argument customDays: (tuple) A way to custom encode specific days of the week.
+
+        - [0] (int) Width of attribute
+        - [1] (str | list) Either a string representing a day of the week like
+          "Monday" or "mon", or a list of these strings.
+
+    Argument holidays: (list) a list of tuples for holidays.
+
+        - Each holiday is either (month, day) or (year, month, day).
+          The former will use the same month day every year eg: (12, 25) for Christmas.
+          The latter will be a one off holiday eg: (2018, 4, 1) for Easter Sunday 2018
+        - By default the only holiday is December 25.
+    """
+    self.size = 0
+
+    self.seasonEncoder = None
+    if season != 0:
+      p = ScalarEncoderParameters()
+      # Ignore leapyear differences -- assume 366 days in a year
+      # Radius = 91.5 days = length of season
+      # Value is number of days since beginning of year (0 - 355)
+      p.minimum  = 0
+      p.maximum  = 366
+      p.periodic = True
+      try:
+        activeBits, radius = season
+      except TypeError:
+        p.activeBits = season
+        p.radius     = 91.5
+      else:
+        p.activeBits = season[0]
+        p.radius     = season[1]
+      self.seasonEncoder = ScalarEncoder(p)
+      self.size += self.seasonEncoder.size
+
+    self.dayOfWeekEncoder = None
+    if dayOfWeek != 0:
+      p = ScalarEncoderParameters()
+      # Value is day of week (floating point)
+      # Radius is 1 day
+      p.minimum  = 0
+      p.maximum  = 7
+      p.periodic = True
+      try:
+        activeBits, radius = dayOfWeek
+      except TypeError:
+        p.activeBits = dayOfWeek
+        p.radius     = 1
+      else:
+        p.activeBits = dayOfWeek[0]
+        p.radius     = dayOfWeek[1]
+      self.dayOfWeekEncoder = ScalarEncoder(p)
+      self.size += self.dayOfWeekEncoder.size
+
+    self.weekendEncoder = None
+    if weekend != 0:
+      p = ScalarEncoderParameters()
+      # Binary value.
+      p.minimum    = 0
+      p.maximum    = 1
+      p.category   = True
+      p.activeBits = weekend
+      self.weekendEncoder = ScalarEncoder(p)
+      self.size += self.weekendEncoder.size
+
+    # Set up custom days encoder, first argument in tuple is width
+    # second is either a single day of the week or a list of the days
+    # you want encoded as ones.
+    self.customDaysEncoder = None
+    if customDays !=0:
+      daysToParse = []
+      assert len(customDays)==2, "Please provide a w and the desired days"
+      if isinstance(customDays[1], list):
+        daysToParse=customDays[1]
+      elif isinstance(customDays[1], str):
+        daysToParse = [customDays[1]]
+      else:
+        raise ValueError("You must provide either a list of days or a single day")
+      # Parse days
+      self.customDays = []
+      for day in daysToParse:
+        if(day.lower() in ["mon","monday"]):
+          self.customDays += [0]
+        elif day.lower() in ["tue","tuesday"]:
+          self.customDays += [1]
+        elif day.lower() in ["wed","wednesday"]:
+          self.customDays += [2]
+        elif day.lower() in ["thu","thursday"]:
+          self.customDays += [3]
+        elif day.lower() in ["fri","friday"]:
+          self.customDays += [4]
+        elif day.lower() in ["sat","saturday"]:
+          self.customDays += [5]
+        elif day.lower() in ["sun","sunday"]:
+          self.customDays += [6]
+        else:
+          raise ValueError("Unable to understand %s as a day of week" % str(day))
+
+      p = ScalarEncoderParameters()
+      p.activeBits = customDays[0]
+      p.minimum    = 0
+      p.maximum    = 1
+      p.category   = True
+      self.customDaysEncoder = ScalarEncoder(p)
+      self.size += self.customDaysEncoder.size
+
+    self.holidayEncoder = None
+    if holiday != 0:
+      p = ScalarEncoderParameters()
+      # A "continuous" binary value. = 1 on the holiday itself and smooth ramp
+      # 0->1 on the day before the holiday and 1->0 on the day after the
+      # holiday.
+      p.minimum    = 0
+      p.maximum    = 1
+      p.radius     = 1
+      p.activeBits = holiday
+      self.holidayEncoder = ScalarEncoder(p)
+      self.size += self.holidayEncoder.size
+
+      for h in holidays:
+        if not (hasattr(h, "__getitem__") or len(h) not in [2,3]):
+          raise ValueError("Holidays must be an iterable of length 2 or 3")
+      self.holidays = holidays
+
+    self.timeOfDayEncoder = None
+    if timeOfDay != 0:
+      p = ScalarEncoderParameters()
+      p.minimum  = 0
+      p.maximum  = 24
+      p.periodic = True
+      # Value is time of day in hours
+      # Radius = 4 hours, e.g. morning, afternoon, evening, early night,  late
+      # night, etc.
+      try:
+        activeBits, radius = timeOfDay
+      except TypeError:
+        p.activeBits = timeOfDay
+        p.radius     = 4
+      else:
+        p.activeBits = timeOfDay[0]
+        p.radius     = timeOfDay[1]
+
+      self.timeOfDayEncoder = ScalarEncoder(p)
+      self.size += self.timeOfDayEncoder.size
+
+    self.dimensions = (self.size,)
+    assert(self.size > 0)
+
+  def reset(self):
+    """ Does nothing, DateEncoder holds no state. """
+    pass
+
+  def encode(self, inp, output=None):
+    """
+    Argument inp: (datetime) representing the time being encoded
+    """
+    if output is None:
+      output = SDR(self.dimensions)
+    else:
+      assert( isinstance(output, SDR) )
+      assert( output.dimensions == self.dimensions )
+
+    if inp is None or (isinstance(inp, float) and math.isnan(inp)):
+      output.zero()
+      return output
+
+    elif not isinstance(inp, datetime.datetime):
+      raise ValueError("Input is type %s, expected datetime. Value: %s" % (
+          type(inp), str(inp)))
+
+    # -------------------------------------------------------------------------
+    # Encode each sub-field
+    sdrs      = []
+    timetuple = inp.timetuple()
+    timeOfDay = timetuple.tm_hour + float(timetuple.tm_min)/60.0
+
+    if self.seasonEncoder is not None:
+      # Number the days starting at zero, intead of 1 like the datetime does.
+      dayOfYear = timetuple.tm_yday - 1
+      # dayOfYear -= self.seasonEncoder.parameters.radius / 2. # Round towards the middle of the season.
+      sdrs.append( self.seasonEncoder.encode(dayOfYear) )
+
+    if self.dayOfWeekEncoder is not None:
+      dayOfWeek = timetuple.tm_wday + (timeOfDay) / 24.0
+      dayOfWeek -= .5 # Round towards noon, not midnight
+      sdrs.append( self.dayOfWeekEncoder.encode(dayOfWeek) )
+
+    if self.weekendEncoder is not None:
+      # saturday, sunday or friday evening
+      if (timetuple.tm_wday == 6 or timetuple.tm_wday == 5 or
+         (timetuple.tm_wday == 4 and timeOfDay > 18)):
+        weekend = 1
+      else:
+        weekend = 0
+      sdrs.append( self.weekendEncoder.encode(weekend) )
+
+    if self.customDaysEncoder is not None:
+      if timetuple.tm_wday in self.customDays:
+        customDay = 1
+      else:
+        customDay = 0
+      sdrs.append( self.customDaysEncoder.encode(customDay) )
+
+    if self.holidayEncoder is not None:
+      # A "continuous" binary value. = 1 on the holiday itself and smooth ramp
+      #  0->1 on the day before the holiday and 1->0 on the day after the holiday.
+      # holidays is a list of holidays that occur on a fixed date every year
+      val = 0
+      for h in self.holidays:
+        # hdate is midnight on the holiday
+        if len(h) == 3:
+          hdate = datetime.datetime(h[0], h[1], h[2], 0, 0, 0)
+        else:
+          hdate = datetime.datetime(timetuple.tm_year, h[0], h[1], 0, 0, 0)
+        if inp > hdate:
+          diff = inp - hdate
+          if diff.days == 0:
+            # return 1 on the holiday itself
+            val = 1
+            break
+          elif diff.days == 1:
+            # ramp smoothly from 1 -> 0 on the next day
+            val = 1.0 - (float(diff.seconds) / 86400)
+            break
+        else:
+          diff = hdate - inp
+          if diff.days == 0:
+            # ramp smoothly from 0 -> 1 on the previous day
+            val = 1.0 - (float(diff.seconds) / 86400)
+
+      sdrs.append( self.holidayEncoder.encode(val) )
+
+    if self.timeOfDayEncoder is not None:
+      sdrs.append( self.timeOfDayEncoder.encode(timeOfDay) )
+
+    if len(sdrs) > 1:
+      output.concatenate( sdrs )
+    else:
+      output.setSDR( sdrs[0] )
+    return output

--- a/py/src/nupic/tests/encoders/date_test.py
+++ b/py/src/nupic/tests/encoders/date_test.py
@@ -51,7 +51,7 @@ class DateEncoderTest(unittest.TestCase):
     # d = datetime.datetime(2010, 11, 1, 8, 55) # DEBUG
     bits = enc.encode(d)
     # Season is aaabbbcccddd (1 bit/month)
-    seasonExpected = [0,0,0,0,0,0,0,0,0,1,1,1]
+    seasonExpected = [1,0,0,0,0,0,0,0,0,0,1,1]
 
     # Week is MTWTFSS contrary to localtime documentation, Monday = 0 (for
     # python datetime.datetime.timetuple()
@@ -65,13 +65,10 @@ class DateEncoderTest(unittest.TestCase):
     # should be 30 bits total (30 * 48 minutes = 24 hours)
     timeOfDayExpected = (
       [0,0,0,0,0,0,0,0,0,0,
-       0,0,0,0,0,0,1,1,1,1,
-       1,0,0,0,0,0,0,0,0,0])
+       0,0,0,0,0,0,0,0,0,1,
+       1,1,1,1,0,0,0,0,0,0])
     expected = seasonExpected + dayOfWeekExpected + weekendExpected + timeOfDayExpected
 
-    print(enc.timeOfDayEncoder.size)
-    print(expected)
-    print(bits.dense.tolist())
     self.assertEqual(bits.size, 51)
     self.assertEqual(expected, bits.dense.tolist())
 
@@ -107,7 +104,7 @@ class DateEncoderTest(unittest.TestCase):
     bits = enc.encode(d)
 
     # Season is aaabbbcccddd (1 bit/month)
-    seasonExpected = [0,0,0,0,0,0,0,0,0,1,1,1]
+    seasonExpected = [1,0,0,0,0,0,0,0,0,0,1,1]
 
     expected = seasonExpected
     self.assertEqual(bits.size, 12)
@@ -149,10 +146,12 @@ class DateEncoderTest(unittest.TestCase):
     # Encoder should be 30 bits total (30 * 48 minutes = 24 hours)
     timeOfDayExpected = (
       [0,0,0,0,0,0,0,0,0,0,
-       0,0,0,0,0,0,1,1,1,1,
-       1,0,0,0,0,0,0,0,0,0])
+       0,0,0,0,0,0,0,0,0,1,
+       1,1,1,1,0,0,0,0,0,0])
 
     expected = timeOfDayExpected
+    print(expected)
+    print(bits.dense.tolist())
     self.assertEqual(bits.size, 30)
     self.assertEqual(expected, bits.dense.tolist())
 
@@ -218,7 +217,8 @@ class DateEncoderTest(unittest.TestCase):
       d = d+datetime.timedelta(days=1)
       self.assertEqual( e.encode(d), e2.encode(d) )
 
-
+  
+  @unittest.skip("Encoding years not supported, DateTime now works at weekly basis only")
   def testYearsDiffer(self):
     """ Creating date encoder instance. """
     enc = DateEncoder(season=1, dayOfWeek=1, weekend=1) #all info for recognizing days 

--- a/py/src/nupic/tests/encoders/date_test.py
+++ b/py/src/nupic/tests/encoders/date_test.py
@@ -26,6 +26,7 @@ import numpy
 import unittest
 
 from nupic.encoders.date import DateEncoder
+from nupic.bindings.sdr import SDR
 
 
 class DateEncoderTest(unittest.TestCase):
@@ -54,16 +55,21 @@ class DateEncoderTest(unittest.TestCase):
     # min = 48min 14:55 is minute 14*60 + 55 = 895; 895/48 = bit 18.6
     # should be 30 bits total (30 * 48 minutes = 24 hours)
     timeOfDayExpected = (
-      [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,0,0,0,0,0,0,0,0,0])
+      [0,0,0,0,0,0,0,0,0,0,
+       0,0,0,0,0,0,1,1,1,1,
+       1,0,0,0,0,0,0,0,0,0])
     expected = numpy.array(seasonExpected +
                            dayOfWeekExpected +
                            weekendExpected +
                            timeOfDayExpected)
+    expectedSdr = SDR(51)
+    expectedSdr.dense = expected
 
     print(enc.timeOfDayEncoder.size)
-    print(expected)
-    print(bits.dense)
-    self.assertEqual(expected, bits.dense)
+    print(expectedSdr)
+    print(bits)
+    self.assertEqual(expectedSdr.size, bits.size)
+    self.assertEqual(expectedSdr, bits)
 
 
   def testMissingValues(self):

--- a/py/src/nupic/tests/encoders/date_test.py
+++ b/py/src/nupic/tests/encoders/date_test.py
@@ -123,9 +123,10 @@ class DateEncoderTest(unittest.TestCase):
   def testWeekend(self):
     """ Test weekend encoder. """
     e  = DateEncoder(customDays=(21, ["sat", "sun", "fri"]))
-    e2 = DateEncoder(weekend=(21, 1))
+    e2 = DateEncoder(weekend=21)
 
     d = datetime.datetime(1988, 5, 29, 20, 00)
+    print(d)
     self.assertEqual( e.encode(d), e2.encode(d) )
 
     for _ in range(300):

--- a/py/src/nupic/tests/encoders/date_test.py
+++ b/py/src/nupic/tests/encoders/date_test.py
@@ -1,0 +1,131 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+""" Unit tests for date encoder. """
+
+import datetime
+import numpy
+import unittest
+
+from nupic.encoders.date import DateEncoder
+
+
+class DateEncoderTest(unittest.TestCase):
+  """ Unit tests for DateEncoder class. """
+
+  def testDateEncoder(self):
+    """ Creating date encoder instance. """
+    # 3 bits for season, 1 bit for day of week, 1 for weekend, 5 for time of day
+    enc = DateEncoder(season=3, dayOfWeek=1, weekend=1, timeOfDay=5)
+    # In the middle of fall, Thursday, not a weekend, afternoon - 4th Nov,
+    # 2010, 14:55
+    d = datetime.datetime(2010, 11, 4, 14, 55)
+    # d = datetime.datetime(2010, 11, 1, 8, 55) # DEBUG
+    bits = enc.encode(d)
+    # Season is aaabbbcccddd (1 bit/month)
+    seasonExpected = [0,0,0,0,0,0,0,0,0,1,1,1]
+
+    # Week is MTWTFSS contrary to localtime documentation, Monday = 0 (for
+    # python datetime.datetime.timetuple()
+    dayOfWeekExpected = [0,0,0,1,0,0,0]
+
+    # Not a weekend, so it should be "False"
+    weekendExpected = [1, 0]
+
+    # Time of day has radius of 4 hours and w of 5 so each bit = 240/5
+    # min = 48min 14:55 is minute 14*60 + 55 = 895; 895/48 = bit 18.6
+    # should be 30 bits total (30 * 48 minutes = 24 hours)
+    timeOfDayExpected = (
+      [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,0,0,0,0,0,0,0,0,0])
+    expected = numpy.array(seasonExpected +
+                           dayOfWeekExpected +
+                           weekendExpected +
+                           timeOfDayExpected)
+
+    print(enc.timeOfDayEncoder.size)
+    print(expected)
+    print(bits.dense)
+    self.assertEqual(expected, bits.dense)
+
+
+  def testMissingValues(self):
+    """ Missing values. """
+    e = DateEncoder(timeOfDay=5)
+    mvOutput = e.encode(None)
+    self.assertEqual(sum(mvOutput.sparse), 0)
+    mvOutput = e.encode(float('nan'))
+    self.assertEqual(sum(mvOutput.sparse), 0)
+
+
+  def testHoliday(self):
+    """ Look at holiday more carefully because of the smooth transition. """
+    e = DateEncoder(holiday=5)
+    holiday    = [0,0,0,0,0,1,1,1,1,1]
+    notholiday = [1,1,1,1,1,0,0,0,0,0]
+    holiday2   = [0,0,0,1,1,1,1,1,0,0]
+
+    d = datetime.datetime(2010, 12, 25, 4, 55)
+    assert(all( e.encode(d).dense == holiday ))
+
+    d = datetime.datetime(2008, 12, 27, 4, 55)
+    assert(all( e.encode(d).dense == notholiday ))
+
+    d = datetime.datetime(1999, 12, 26, 8, 00)
+    assert(all( e.encode(d).dense == holiday2 ))
+
+    d = datetime.datetime(2011, 12, 24, 16, 00)
+    assert(all( e.encode(d).dense == holiday2 ))
+
+
+  def testHolidayMultiple(self):
+    """ Look at holiday more carefully because of the smooth transition. """
+    e = DateEncoder(holiday=5, holidays=[(12, 25), (2018, 4, 1), (2017, 4, 16)])
+    holiday    = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
+    notholiday = [1, 1, 1, 1, 1, 0, 0, 0, 0, 0]
+
+    d = datetime.datetime(2011, 12, 25, 4, 55)
+    assert(all( e.encode(d).dense == holiday ))
+
+    d = datetime.datetime(2007, 12, 2, 4, 55)
+    assert(all( e.encode(d).dense == notholiday ))
+
+    d = datetime.datetime(2018, 4, 1, 16, 10)
+    assert(all( e.encode(d).dense == holiday ))
+
+    d = datetime.datetime(2017, 4, 16, 16, 10)
+    assert(all( e.encode(d).dense == holiday ))
+
+
+  def testWeekend(self):
+    """ Test weekend encoder. """
+    e  = DateEncoder(customDays=(21, ["sat", "sun", "fri"]))
+    e2 = DateEncoder(weekend=(21, 1))
+
+    d = datetime.datetime(1988, 5, 29, 20, 00)
+    self.assertEqual( e.encode(d), e2.encode(d) )
+
+    for _ in range(300):
+      d = d+datetime.timedelta(days=1)
+      self.assertEqual( e.encode(d), e2.encode(d) )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/py/src/nupic/tests/encoders/date_test.py
+++ b/py/src/nupic/tests/encoders/date_test.py
@@ -219,5 +219,14 @@ class DateEncoderTest(unittest.TestCase):
       self.assertEqual( e.encode(d), e2.encode(d) )
 
 
+  def testYearsDiffer(self):
+    """ Creating date encoder instance. """
+    enc = DateEncoder(season=1, dayOfWeek=1, weekend=1) #all info for recognizing days 
+    # 1.1. 2007 & 2018 was Monday, can you recognize the days?
+    first2007 = datetime.datetime(2007, 1, 1) #FIXME enc fails to encode this? 
+    first2018 = datetime.datetime(2018, 1, 1)
+    self.assertNotEqual(enc.encode(first2007).dense.tolist(), 
+                        enc.encode(first2018).dense.tolist()) 
+
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Here you go Breznak, this is as far as I got with the date & time encoder.  Please feel free to take over this issue.

One of the unit tests fails because the new encoder does not center the activity in the same way that the old one did.

The other failure appears to be because the test does not comply with the given documentation?