### PR TITLE
Python SDR.flatten() & return SDRs

### DIFF
--- a/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
+++ b/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
@@ -211,9 +211,10 @@ dimension in the SDR. The inner lists contain the coordinates of each true bit.
 The inner lists run in parallel. This format is useful because it contains the
 location of each true bit inside of the SDR's dimensional space.)");
 
-        py_SDR.def("setSDR", [](SDR &self, SDR &other) {
-            NTA_CHECK( self.dimensions == other.dimensions );
-            self.setSDR( other ); },
+        py_SDR.def("setSDR", [](SDR *self, SDR &other) {
+            NTA_CHECK( self->dimensions == other.dimensions );
+            self->setSDR( other );
+            return self; },
 R"(Deep Copy the given SDR to this SDR.  This overwrites the current value of this
 SDR.  This SDR and the given SDR will have no shared data and they can be
 modified without affecting each other.)");
@@ -258,9 +259,10 @@ RNGs must be instances of "nupic.bindings.math.Random".)",
                 py::arg("sparsity"),
                 py::arg("rng"));
 
-        py_SDR.def("addNoise", [](SDR &self, Real fractionNoise, UInt seed = 0) {
+        py_SDR.def("addNoise", [](SDR *self, Real fractionNoise, UInt seed) {
             Random rng( seed );
-            self.addNoise( fractionNoise, rng ); },
+            self->addNoise( fractionNoise, rng );
+            return self; },
 R"(Modify the SDR by moving a fraction of the active bits to different
 locations.  This method does not change the sparsity of the SDR, it moves
 the locations of the true values.  The resulting SDR has a controlled

--- a/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
+++ b/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
@@ -322,6 +322,9 @@ Argument dimensions A list of dimension sizes, defining the shape of the SDR.)",
             { return new Reshape(self, dimensions); },
 R"(See class nupic.bindings.sdr.Reshape)");
 
+        py_SDR.def("flatten", [](SDR &self)
+            { return new Reshape(self, {self.size}); },
+R"(See class nupic.bindings.sdr.Reshape)");
 
         py_SDR.def("intersection", [](SDR *self, SDR& inp1, SDR& inp2)
             { self->intersection({ &inp1, &inp2}); return self; },
@@ -348,8 +351,8 @@ Example Usage:
         py_SDR.def("intersection", [](SDR *self, vector<const SDR*> inputs)
             { self->intersection(inputs); return self; });
 
-        py_SDR.def("concatenate", [](SDR &self, const SDR& inp1, const SDR& inp2, UInt axis)
-            { self.concatenate(inp1, inp2, axis); },
+        py_SDR.def("concatenate", [](SDR *self, const SDR& inp1, const SDR& inp2, UInt axis)
+            { self->concatenate(inp1, inp2, axis); return self; },
 R"(Concatenates SDRs and stores the result in this SDR.
 
 This method has two overloads:
@@ -376,8 +379,8 @@ Example Usage:
                 py::arg("input2"),
                 py::arg("axis") = 0u );
 
-        py_SDR.def("concatenate", [](SDR &self, vector<const SDR*> inputs, UInt axis)
-            { self.concatenate(inputs, axis); },
+        py_SDR.def("concatenate", [](SDR *self, vector<const SDR*> inputs, UInt axis)
+            { self->concatenate(inputs, axis); return self; },
                 py::arg("inputs"),
                 py::arg("axis") = 0u );
     }

--- a/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
+++ b/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
@@ -232,9 +232,9 @@ I.E.  sparsity = sdr.getSum() / sdr.size)");
 "Calculates the number of true bits which both SDRs have in common.");
 
         py_SDR.def("randomize",
-            [](SDR &self, Real sparsity, UInt seed) {
+            [](SDR *self, Real sparsity, UInt seed) {
             Random rng( seed );
-            self.randomize( sparsity, rng );
+            self->randomize( sparsity, rng );
             return self; },
 R"(Make a random SDR, overwriting the current value of the SDR.  The result has
 uniformly random activations.
@@ -250,8 +250,8 @@ special, it is replaced with the system time  The default seed is 0.)",
 
         py::module::import("nupic.bindings.math");
         py_SDR.def("randomize",
-            [](SDR &self, Real sparsity, Random rng) {
-            self.randomize( sparsity, rng );
+            [](SDR *self, Real sparsity, Random rng) {
+            self->randomize( sparsity, rng );
             return self; },
 R"(This overload accepts Random Number Generators (RNG) intead of a random seed.
 RNGs must be instances of "nupic.bindings.math.Random".)",
@@ -323,8 +323,8 @@ Argument dimensions A list of dimension sizes, defining the shape of the SDR.)",
 R"(See class nupic.bindings.sdr.Reshape)");
 
 
-        py_SDR.def("intersection", [](SDR &self, SDR& inp1, SDR& inp2)
-            { self.intersection({ &inp1, &inp2}); },
+        py_SDR.def("intersection", [](SDR *self, SDR& inp1, SDR& inp2)
+            { self->intersection({ &inp1, &inp2}); return self; },
 R"(This method calculates the set intersection of the active bits in each input
 SDR.
 
@@ -345,8 +345,8 @@ Example Usage:
     X.intersection( A, B )
     X.sparse -> [2, 3]
 )");
-        py_SDR.def("intersection", [](SDR &self, vector<const SDR*> inputs)
-            { self.intersection(inputs); });
+        py_SDR.def("intersection", [](SDR *self, vector<const SDR*> inputs)
+            { self->intersection(inputs); return self; });
 
         py_SDR.def("concatenate", [](SDR &self, const SDR& inp1, const SDR& inp2, UInt axis)
             { self.concatenate(inp1, inp2, axis); },

--- a/bindings/py/tests/sdr/SDR_test.py
+++ b/bindings/py/tests/sdr/SDR_test.py
@@ -240,6 +240,9 @@ class SdrTest(unittest.TestCase):
             pass
         else:
             self.fail()
+        # Check return value.
+        D = A.setSDR( B )
+        assert( D is A )
 
     def testGetSum(self):
         A = SDR((103,))
@@ -316,18 +319,21 @@ class SdrTest(unittest.TestCase):
         B.setSDR( A )
         A.addNoise( .5 )
         assert( A.getOverlap(B) == 5 )
-
+        # Check different seed makes different results.
         A.randomize( .3, 42 )
         B.randomize( .3, 42 )
         A.addNoise( .5 )
         B.addNoise( .5 )
         assert( A != B )
-
+        # Check same seed makes same results.
         A.randomize( .3, 42 )
         B.randomize( .3, 42 )
         A.addNoise( .5, 42 )
         B.addNoise( .5, 42 )
         assert( A == B )
+        # Check that it returns itself.
+        C = A.addNoise( .5 )
+        assert( C is A )
 
     def testStr(self):
         A = SDR((103,))

--- a/bindings/py/tests/sdr/SDR_test.py
+++ b/bindings/py/tests/sdr/SDR_test.py
@@ -480,6 +480,17 @@ class ConcatenationTest(unittest.TestCase):
         CD.concatenate([C, D], axis=1)
         CD.concatenate(inputs=[C, D], axis=1)
 
+    def testReturn(self):
+        """
+        Check that the following short hand will work, and will not incur extra copying:
+        >>> C = SDR( A.size + B.size ).concatenate( A.flatten(), B.flatten() )
+        """
+        A = SDR(( 10, 10 )).randomize( .5 )
+        B = SDR(( 10, 10 )).randomize( .5 )
+        C = SDR( A.size + B.size )
+        D = C.concatenate( A.flatten(), B.flatten() )
+        assert( C is D )
+
     def testMirroring(self):
         A = SDR( 100 )
         A.randomize( .05 )

--- a/bindings/py/tests/sdr/SDR_test.py
+++ b/bindings/py/tests/sdr/SDR_test.py
@@ -304,6 +304,11 @@ class SdrTest(unittest.TestCase):
         z = SDR(1000).randomize(.5, Random(77))
         assert( x == z )
 
+    def testRandomizeReturn(self):
+        X = SDR( 100 )
+        Y = X.randomize( .2 )
+        assert( X is Y )
+
     def testAddNoise(self):
         A = SDR((103,))
         B = SDR((103,))
@@ -402,6 +407,13 @@ class IntersectionTest(unittest.TestCase):
         B.randomize(  .50 )
         A.intersection( B, A )
         assert( A.getSparsity() == .5 )
+
+    def testReturn(self):
+        A = SDR( 10 ).randomize( .5 )
+        B = SDR( 10 ).randomize( .5 )
+        X = SDR( A.dimensions )
+        Y = X.intersection( A, B )
+        assert( X is Y )
 
     def testSparsity(self):
         test_cases = [


### PR DESCRIPTION
New python method `sdr.flatten()` which returns the SDR after reshaping it into one big dimension.

Also made several SDR methods return the SDR.  This is a convenience, it allow the user to chain multiple calls to an SDR onto one line like:
```Python
A = SDR( 100 ).randomize( .5 )
B = SDR( 100 ).randomize( .5 )
X = SDR( A.dimensions ).intersection( A, B )
```