### PR TITLE
Python SpatialPooler Bindings fix for numActiveColumnsPerInhArea

### DIFF
--- a/bindings/py/cpp_src/bindings/algorithms/py_SpatialPooler.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_SpatialPooler.cpp
@@ -58,7 +58,7 @@ using namespace sdr;
             , Real
             , bool
             , Real
-            , UInt
+            , Int
             , UInt
             , Real
             , Real


### PR DESCRIPTION
Argument numActiveColumnsPerInhArea needs to be signed so that
it can be disabled (set to -1).  Otherwise it's impossible to use
argument localAreaDensity since the two are mutually exclusive.