### PR TITLE
Python SDR.flatten() fix

### DIFF
--- a/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
+++ b/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
@@ -325,8 +325,11 @@ Argument dimensions A list of dimension sizes, defining the shape of the SDR.)",
 R"(See class nupic.bindings.sdr.Reshape)");
 
         py_SDR.def("flatten", [](SDR &self)
-            { return new Reshape(self, {self.size}); },
-R"(See class nupic.bindings.sdr.Reshape)");
+            {
+                auto flat = new SDR({ self.size });
+                flat->setSparse( self.getSparse() );
+                return flat; },
+R"(Returns a copy of this SDR with one big dimension, like numpy.ndarray.flatten())");
 
         py_SDR.def("intersection", [](SDR *self, SDR& inp1, SDR& inp2)
             { self->intersection({ &inp1, &inp2}); return self; },


### PR DESCRIPTION
Previously this used the Reshape class to avoid copying the data.
Now this copies the data into a new object.

The problem was that python would garbage collect the data source
because the Reshape class does not use smart pointers to keep it
alive.  With a data copy into a new object this is no longer an
issue.

I'm begining to think that the Reshape class isn't well designed.
I probably should have listened to my reviewers...