### PR TITLE
Pybind11 SpatialPooler fix for printing durring constructor.

### DIFF
--- a/bindings/py/cpp_src/bindings/algorithms/py_SpatialPooler.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_SpatialPooler.cpp
@@ -69,6 +69,8 @@ using namespace sdr;
             , Int
             , UInt
             , bool>()
+            , py::call_guard<py::scoped_ostream_redirect,
+                             py::scoped_estream_redirect>()
             , py::arg("inputDimensions") = vector<UInt>({ 32, 32 })
             , py::arg("columnDimensions") = vector<UInt>({ 64, 64 })
             , py::arg("potentialRadius") = 16
@@ -89,6 +91,8 @@ using namespace sdr;
         );
 
         py_SpatialPooler.def("initialize", &SpatialPooler::initialize
+            , py::call_guard<py::scoped_ostream_redirect,
+                             py::scoped_estream_redirect>()
             , py::arg("inputDimensions") = vector<UInt>({ 32, 32 })
             , py::arg("columnDimensions") = vector<UInt>({ 64, 64 })
             , py::arg("potentialRadius") = 16


### PR DESCRIPTION
From the docs:

https://pybind11.readthedocs.io/en/stable/advanced/pycpp/utilities.html#capturing-standard-output-from-ostream

Often, a library will use the streams std::cout and std::cerr to
print, but this does not play well with Python’s standard sys.stdout
and sys.stderr redirection. Replacing a library’s printing with
py::print may not be feasible. This can be fixed using a guard
around the library function that redirects output to the
corresponding Python streams ...