### PR TITLE
Python SDR.zero() returns the sdr.

### DIFF
--- a/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
+++ b/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
@@ -139,7 +139,7 @@ other.)",
                 return self.size; },
             "The total number of boolean values in the SDR.");
 
-        py_SDR.def("zero", &SDR::zero,
+        py_SDR.def("zero", [](SDR *self) { self->zero(); return self; },
 R"(Set all of the values in the SDR to false.  This method overwrites the SDRs
 current value.)");
 

--- a/bindings/py/tests/sdr/SDR_test.py
+++ b/bindings/py/tests/sdr/SDR_test.py
@@ -89,8 +89,9 @@ class SdrTest(unittest.TestCase):
     def testZero(self):
         A = SDR((103,))
         A.sparse = list(range(20))
-        A.zero()
+        B = A.zero()
         assert( np.sum( A.dense ) == 0 )
+        assert( A is B )
 
     def testDense(self):
         A = SDR((103,))


### PR DESCRIPTION
Convenience, allows user to chain several SDR method calls on one line.
All of the other SDR methods return the SDR when applicable, and
sdr.zero did not, which is inconsistent.