### PR TITLE
Re-allow builds with Anaconda Python (Only Python 3 checked)

### DIFF
--- a/bindings/py/cpp_src/bindings/algorithms/py_SpatialPooler.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_SpatialPooler.cpp
@@ -46,7 +46,6 @@ using namespace nupic;
 using namespace nupic::algorithms::spatial_pooler;
 using namespace sdr;
 
-
     void init_Spatial_Pooler(py::module& m)
     {
         py::class_<SpatialPooler> py_SpatialPooler(m, "SpatialPooler");
@@ -252,21 +251,21 @@ using namespace sdr;
         });
 
         // getPermanence
-        py_SpatialPooler.def("getPermanence", [](const SpatialPooler& self, UInt column, py::array_t<Real>& x)
+        py_SpatialPooler.def("getPermanence", [](const SpatialPooler& self, UInt column, py::array& x)
         {
-            self.getPermanence(column, get_it(x));
+            self.getPermanence(column, get_it<Real>(FLOAT_PRECISION, x));
         });
 
         // getConnectedSynapses
-        py_SpatialPooler.def("getConnectedSynapses", [](const SpatialPooler& self, UInt column, py::array_t<UInt>& x)
+        py_SpatialPooler.def("getConnectedSynapses", [](const SpatialPooler& self, UInt column, py::array& x)
         {
-            self.getConnectedSynapses(column, get_it(x));
+            self.getConnectedSynapses(column, get_it<UInt>(INT_PRECISION, x));
         });
 
         // getConnectedCounts
-        py_SpatialPooler.def("getConnectedCounts", [](const SpatialPooler& self, py::array_t<UInt>& x)
+        py_SpatialPooler.def("getConnectedCounts", [](const SpatialPooler& self, py::array& x)
         {
-            self.getConnectedCounts(get_it(x));
+            self.getConnectedCounts(get_it<UInt>(INT_PRECISION, x));
         });
 
         // getOverlaps

--- a/bindings/py/cpp_src/bindings/algorithms/py_SpatialPooler.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_SpatialPooler.cpp
@@ -253,19 +253,19 @@ using namespace sdr;
         // getPermanence
         py_SpatialPooler.def("getPermanence", [](const SpatialPooler& self, UInt column, py::array& x)
         {
-            self.getPermanence(column, get_it<Real>(FLOAT_PRECISION, x));
+            self.getPermanence(column, get_it<Real>(sizeof(Real), x));
         });
 
         // getConnectedSynapses
         py_SpatialPooler.def("getConnectedSynapses", [](const SpatialPooler& self, UInt column, py::array& x)
         {
-            self.getConnectedSynapses(column, get_it<UInt>(INT_PRECISION, x));
+            self.getConnectedSynapses(column, get_it<UInt>(sizeof(UInt), x));
         });
 
         // getConnectedCounts
         py_SpatialPooler.def("getConnectedCounts", [](const SpatialPooler& self, py::array& x)
         {
-            self.getConnectedCounts(get_it<UInt>(INT_PRECISION, x));
+            self.getConnectedCounts(get_it<UInt>(sizeof(UInt), x));
         });
 
         // getOverlaps

--- a/bindings/py/cpp_src/bindings/engine/py_utils.hpp
+++ b/bindings/py/cpp_src/bindings/engine/py_utils.hpp
@@ -41,6 +41,16 @@ namespace nupic_ext {
     template<typename T> T* get_end(py::array_t<T>& a) { return ((T*)a.request().ptr) + a.size(); }
 
     template<typename T> T* get_it(py::array& a) { return (T*)a.request().ptr; }
+
+    // Check that the precision in bytes matches the data size of the array
+    template<typename T> T* get_it( int precision, py::array& a)
+	{
+	if (precision != a.request().itemsize)
+		{throw std::invalid_argument("Invalid numpy array precision used.");}
+
+	return (T*)a.request().ptr;
+	}
+
     template<typename T> T* get_end(py::array& a) { return ((T*)a.request().ptr) + a.size(); }
 
     template<typename T> T* get_row_it(py::array_t<T>& a, int row)

--- a/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
+++ b/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
@@ -298,31 +298,9 @@ special, it is replaced with the system time.  The default seed is 0.)",
                 return self;
         }));
 
-
-        py::class_<Reshape, shared_ptr<Reshape>, SDR> py_Reshape(m, "Reshape",
-R"(Reshape presents a view onto an SDR with different dimensions.
-    * The resulting SDR always has the same value as its source SDR.
-    * The resulting SDR is read only.
-
-Example Usage:
-    # Convert SDR dimensions from (4 x 4) to (8 x 2)
-    A = SDR([ 4, 4 ])
-    B = Reshape( A, [8, 2])
-    A.coordinates =  ([1, 1, 2], [0, 1, 2])
-    B.coordinates -> ([2, 2, 5], [0, 1, 0])
-
-Reshape supports pickle, however loading a pickled SDR Reshape will return
-an SDR object, not a Reshape object.)");
-
-        py_Reshape.def( py::init<SDR&, vector<UInt>>(),
-R"(Argument sdr is the data source to reshape.
-
-Argument dimensions A list of dimension sizes, defining the shape of the SDR.)",
-            py::arg("sdr"), py::arg("dimensions"));
-
-        py_SDR.def("reshape", [](SDR &self, vector<UInt> dimensions)
-            { return new Reshape(self, dimensions); },
-R"(See class nupic.bindings.sdr.Reshape)");
+        py_SDR.def("reshape", [](SDR *self, const vector<UInt> &dimensions)
+            { self->reshape( dimensions ); return self; },
+R"(Change the dimensions of the SDR.  The total size must not change.)");
 
         py_SDR.def("flatten", [](SDR &self)
             {

--- a/bindings/py/cpp_src/plugin/PyBindRegion.hpp
+++ b/bindings/py/cpp_src/plugin/PyBindRegion.hpp
@@ -74,6 +74,14 @@ namespace nupic
         void deserialize(BundleIO& bundle) override;
 
 
+		    bool operator==(const RegionImpl &other) const override {
+					NTA_THROW << " ==  not implemented yet for PyBindRegion.";
+				}
+		    inline bool operator!=(const PyBindRegion &other) const {
+		      return !operator==(other);
+		    }
+				// TODO: implement compare of two .py implemented Regions.
+
 
         ////////////////////////////
         // RegionImpl

--- a/bindings/py/packaging/setup.py
+++ b/bindings/py/packaging/setup.py
@@ -204,10 +204,6 @@ def generateExtensions():
     PY_VER = "-DBINDING_BUILD=Python2"
 
   print("Python version: {}\n".format(sys.version))
-  #detect Anaconda python interpreter
-  is_conda = os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
-  if is_conda:
-    raise Exception("Anaconda python not supported!\n")
 
   scriptsDir = os.path.join(REPO_DIR, "build", "scripts")
   try:

--- a/bindings/py/tests/algorithms/spatial_pooler_test.py
+++ b/bindings/py/tests/algorithms/spatial_pooler_test.py
@@ -64,15 +64,26 @@ class SpatialPoolerTest(unittest.TestCase):
       total = total + perms
     assert( total.sum() > 0.0 )
     
-  def testGetPermanence(self):
+  def testGetPermanenceFloat64(self):
     """ Check that getPermanence() returns values. """
     try:
       # This is when NTA_DOUBLE_PRECISION is true
       self._runGetPermanenceTrial(np.float64)
       
-    except:
-      # This is the normal precision
-      self._runGetPermanenceTrial(np.float32)     
+    except ValueError:
+      # This has caught wrong precision error
+      print("Successfully caught incorrect float numpy data length")
+      pass     
+
+  def testGetPermanenceFloat32(self):
+    """ Check that getPermanence() returns values. """
+    try:
+      self._runGetPermanenceTrial(np.float32)
+      
+    except ValueError:
+      print("Successfully caught incorrect float numpy data length")
+      # This has correctly caught wrong precision error
+      pass     
 
   def _runGetConnectedSynapses(self, uint_type):
     """ Check that getConnectedSynapses() returns values. """
@@ -91,15 +102,27 @@ class SpatialPoolerTest(unittest.TestCase):
       total = total + connected
     assert( total.sum() > 0 )
 
-  def testGetConnectedSynapses(self):
+  def testGetConnectedSynapsesUint64(self):
     """ Check that getConnectedSynapses() returns values. """
     try:
       # This is when NTA_DOUBLE_PRECISION is true
       self._runGetConnectedSynapses(np.uint64)
       
-    except:
-      # This is the normal precision
+    except ValueError:
+      # This has correctly caught wrong precision error
+      print("Successfully caught incorrect uint numpy data length")
+      pass     
+
+  def testGetConnectedSynapsesUint32(self):
+    """ Check that getConnectedSynapses() returns values. """
+    try:
+      # This is when NTA_DOUBLE_PRECISION is true
       self._runGetConnectedSynapses(np.uint32)
+      
+    except ValueError:
+      # This has correctly caught wrong precision error
+      print("Successfully caught incorrect uint numpy data length")
+      pass     
 
   def _runGetConnectedCounts(self, uint_type):
     """ Check that getConnectedCounts() returns values. """
@@ -115,15 +138,27 @@ class SpatialPoolerTest(unittest.TestCase):
     sp.getConnectedCounts(connected)
     assert( connected.sum() > 0 )
 
-  def testGetConnectedCounts(self):
+  def testGetConnectedCountsUint64(self):
     """ Check that getConnectedCounts() returns values. """
     try:
       # This is when NTA_DOUBLE_PRECISION is true
       self._runGetConnectedCounts(np.uint64)
       
-    except:
-      # This is the normal precision
+    except ValueError:
+      # This has correctly caught wrong precision error
+      print("Successfully caught incorrect uint numpy data length")
+      pass     
+
+  def testGetConnectedCountsUint32(self):
+    """ Check that getConnectedCounts() returns values. """
+    try:
+      # This is when NTA_DOUBLE_PRECISION is true
       self._runGetConnectedCounts(np.uint32)
+      
+    except ValueError:
+      # This has correctly caught wrong precision error
+      print("Successfully caught incorrect uint numpy data length")
+      pass     
 
 
 if __name__ == "__main__":

--- a/bindings/py/tests/sdr/SDR_test.py
+++ b/bindings/py/tests/sdr/SDR_test.py
@@ -26,7 +26,7 @@ import unittest
 import pytest
 import time
 
-from nupic.bindings.sdr import SDR, Reshape
+from nupic.bindings.sdr import SDR
 from nupic.bindings.math import Random
 
 class SdrTest(unittest.TestCase):
@@ -360,37 +360,13 @@ class SdrTest(unittest.TestCase):
             B = pickle.loads( P )
             assert( A == B )
 
-
-class ReshapeTest(unittest.TestCase):
-    def testExampleUsage(self):
-        assert( issubclass(Reshape, SDR) )
+    def testReshape(self):
         # Convert SDR dimensions from (4 x 4) to (8 x 2)
         A = SDR([ 4, 4 ])
-        B = Reshape( A, [8, 2])
-        A.coordinates =  ([1, 1, 2], [0, 1, 2])
+        A.coordinates = ([1, 1, 2], [0, 1, 2])
+        B = A.reshape([8, 2])
         assert( (np.array(B.coordinates) == ([2, 2, 5], [0, 1, 0]) ).all() )
-
-    def testLostSDR(self):
-        # You need to keep a reference to the SDR, since SDR class does not use smart pointers.
-        B = Reshape(SDR((1000,)), [1000])
-        with self.assertRaises(RuntimeError):
-            B.dense
-
-    def testChaining(self):
-        A = SDR([10,10])
-        B = Reshape(A, [100])
-        C = Reshape(B, [4, 25])
-        D = B.reshape([1, 100]) # Test convenience method.
-
-        A.dense.fill( 1 )
-        A.dense = A.dense
-        assert( len(C.sparse) == A.size )
-        assert( len(D.sparse) == A.size )
-        del B
-
-    @pytest.mark.skip(reason="Known issue: https://github.com/htm-community/nupic.cpp/issues/160")
-    def testPickle(self):
-        assert(False) # TODO: Unimplemented
+        assert( A is B )
 
 
 class IntersectionTest(unittest.TestCase):

--- a/py/src/nupic/optimization/ae.py
+++ b/py/src/nupic/optimization/ae.py
@@ -80,8 +80,9 @@ the program, as well as diagnostic information such as timestamps and memory
 usage reports.
 """
 
-# TODO: Default parameters need better handling...  When they change, update
-# all of the modifications to be diffs from the new parameters?
+# TODO: Default parameters need better handling...  When they change, update all
+# of the modifications to be diffs from the new parameters?  I could scrape the
+# correct parameters from the experiment journal.
 
 # TODO: Maybe the command line invocation should be included in the experiment
 # hash?  Then I could experiment with the CLI args within a single lab report.
@@ -107,6 +108,9 @@ usage reports.
 # parameters instead of the modifications.  This is useful for swarming which
 # touches every parameter.
 
+# TODO: Add a field to each experiment summary stating how many times it has
+# crashed?
+
 import argparse
 import os
 import sys
@@ -123,6 +127,14 @@ import numpy as np
 import scipy.stats
 
 from nupic.optimization.parameter_set import ParameterSet
+
+acceptable_exceptions = [
+    TypeError,
+    ValueError,
+    MemoryError,
+    ZeroDivisionError,
+    AssertionError,
+    RuntimeError,]
 
 class Experiment:
     """
@@ -537,39 +549,41 @@ class Worker(Process):
             experiment_journal.write(Laboratory.section_divider)
             experiment_journal.write(content)
         os.remove( self.journal )
+        self.journal = content
 
     def collect_score(self, experiment):
         """
         Get the score returned by this run, saved as attribute 'score'.
         Score may be an exception raised by the experiment.
         """
-        assert( self.output.poll(0) )
         experiment.attempts += 1
-        self.score = self.output.recv()
-        if not isinstance(self.score, Exception):
-            experiment.scores.append(self.score)
-        else:
-            for err in (ValueError, MemoryError, ZeroDivisionError, AssertionError, RuntimeError):
-                if isinstance( self.score, err ):
-                    print("")
-                    print( str( experiment.parameters ))
-                    print("Hash: %X" % hash( experiment.parameters ))
-                    print("%s:"%(type( self.score).__name__),  self.score)
-                    print("")
-                    break
+        if self.output.poll(0):
+            self.score = self.output.recv()
+            if not isinstance(self.score, Exception):
+                experiment.scores.append(self.score)
             else:
                 print("")
-                print( str( experiment.parameters ))
+                print("Parameters", str( experiment.parameters ))
                 print("Hash: %X" % hash( experiment.parameters ))
-                print("%s:"%(type(self.result).__name__), self.result)
-                print("Unhandled Exception.")
                 print("")
-                raise
+                print("%s:"%(type( self.score).__name__),  self.score)
+                print("")
+                for err in acceptable_exceptions:
+                    if isinstance( self.score, err ):
+                        break
+                else:
+                    print("Unhandled Exception, Exit.")
+                    sys.exit(1)
+        else:
+            # No output from python?  Something went very wrong!
+            print( self.journal )
+            print("Error, Exit.")
+            sys.exit(1)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--verbose', action='store_true',
+    parser.add_argument('-v', '--verbose', action='store_true',
         help='Passed onto the experiment\'s main function.')
     parser.add_argument('--tag', type=str,
         help='Optional string appended to the name of the AE directory.  Use tags to '

--- a/py/src/nupic/optimization/optimizers.py
+++ b/py/src/nupic/optimization/optimizers.py
@@ -111,6 +111,12 @@ class EvaluateBestExperiment(BaseOptimizer):
     def use_this_optimizer(args):
         return args.best
 
+    def __init__(self, lab, args):
+        super().__init__(lab, args)
+        if lab.verbose:
+            print("Best parameters:")
+            print(str( self.suggest_parameters() ))
+
     def suggest_parameters(self):
         best = max(self.lab.experiments, key = lambda X: X.mean() )
         return best.parameters

--- a/py/src/nupic/optimization/swarming.py
+++ b/py/src/nupic/optimization/swarming.py
@@ -22,16 +22,19 @@
 
 # TODO: Add notes to experiment summaries that they were created by swarming.
 
-# TODO: Make CLI Arguments for these global constants: particle_strength, global_strength, velocity_strength
-particle_strength   =  .25
-global_strength     =  .50
-velocity_strength   =  .95
+# TODO: Make CLI Arguments for these global constants?
+particle_strength   =  .12
+global_strength     =  .25
+velocity_strength   =  .90
+score_decay_rate    =  .001
 assert(velocity_strength + particle_strength / 2 + global_strength / 2 >= 1)
 
 import sys
 import os
 import random
 import pickle
+import numpy as np
+import math
 
 from nupic.optimization.parameter_set import ParameterSet
 from nupic.optimization.optimizers import BaseOptimizer
@@ -45,30 +48,37 @@ class ParticleData:
         p.score      - float
         p.age        - Number of times this particle has been evaluated/updated.
     """
-    def __init__(self, default_parameters):
-        self.parameters = ParameterSet( default_parameters )
+    def __init__(self, initial_parameters, swarm=None):
+        self.parameters = ParameterSet( initial_parameters )
         self.best       = None
         self.best_score = None
         self.age        = 0
-        self.initialize_velocities()
+        self.initialize_velocities(swarm)
 
-    def initialize_velocities(self):
+    def initialize_velocities(self, swarm=None):
         # Make a new parameter structure for the velocity data.
         self.velocities = ParameterSet( self.parameters )
         # Iterate through every field in the structure.
         for path in self.parameters.enumerate():
             value = self.parameters.get(path)
-            max_percent_change = 10
-            uniform = 2 * random.random() - 1
-            if isinstance(value, float):
-                velocity = value * uniform * (max_percent_change / 100.)
-            elif isinstance(value, int):
-                if abs(value) < 10:
-                    velocity = uniform
-                else:
-                    velocity = value * uniform * (max_percent_change / 100.)
+            if swarm is not None:
+                # Analyse the other particle velocities, so that the new
+                # velocity is not too large or too small.
+                data = [p.velocities.get(path) for p in swarm if p is not self]
+                velocity = np.random.normal(np.mean(data), np.std(data))
             else:
-                raise NotImplementedError()
+                # New swarm, start with a large random velocity.
+                max_percent_change = .10
+                uniform = 2 * random.random() - 1
+                if isinstance(value, float):
+                    velocity = value * uniform * max_percent_change
+                elif isinstance(value, int):
+                    if abs(value) < 1. / max_percent_change:
+                        velocity = uniform # Parameters are rounded, so 50% chance this will mutate.
+                    else:
+                        velocity = value * uniform * max_percent_change
+                else:
+                    raise NotImplementedError()
             self.velocities.apply( path, velocity )
 
     def update_position(self):
@@ -92,12 +102,14 @@ class ParticleData:
 
     def update(self, score, global_best):
         self.age += 1
-        self.update_position()
-        self.update_velocity( global_best )
+        if self.best_score is not None:
+            self.best_score *= 1 - score_decay_rate
         if self.best is None or score > self.best_score:
-            self.best       = self.parameters
+            self.best       = ParameterSet( self.parameters )
             self.best_score = score
             print("New particle best score %g."%self.best_score)
+        self.update_position()
+        self.update_velocity( global_best )
 
 
 class ParticleSwarmOptimization(BaseOptimizer):
@@ -148,12 +160,11 @@ class ParticleSwarmOptimization(BaseOptimizer):
                 new_particle = ParticleData( self.best )
             else:
                 new_particle = ParticleData( self.lab.default_parameters )
-            self.swarm.append( new_particle )
             # Evaluate the default parameters a few times, before branching out
             # to the more experimental stuff.
-            if( len(self.swarm) > 3 ):
+            if( len(self.swarm) >= 3 ):
                 new_particle.update_position()
-                new_particle.update_position()
+            self.swarm.append( new_particle )
 
     def suggest_parameters(self):
         particle_data = self.swarm[self.next_particle]
@@ -162,11 +173,14 @@ class ParticleSwarmOptimization(BaseOptimizer):
         return particle_data.parameters
 
     def collect_results(self, parameters, score):
+        # Get the particle for these parameters.
         for particle in self.swarm:
             if particle.parameters == parameters:
                 break
+        else:
+            raise Exception("Unrecognized parameters!")
 
-        if isinstance(score, Exception):
+        if isinstance(score, Exception) or math.isnan(score):
             # Program crashed, replace this particle.
             if particle.best is not None:
                 particle.parameters = ParameterSet( particle.best )
@@ -174,15 +188,17 @@ class ParticleSwarmOptimization(BaseOptimizer):
                 particle.parameters = ParameterSet( self.best )
             else:
                 particle.parameters = ParameterSet( self.lab.default_parameters)
-            particle.initialize_velocities()
+            particle.initialize_velocities( self.swarm )
             particle.update_position()
         else:
             # Update with results of this particles evaluation.
-            particle.update( score, self.best )
+            if self.best_score is not None:
+                self.best_score *= 1 - score_decay_rate / len(self.swarm)
             if self.best is None or score > self.best_score:
-                self.best       = particle.parameters
+                self.best       = ParameterSet( particle.parameters )
                 self.best_score = score
                 print("New global best score %g."%score)
+            particle.update( score, self.best )
         self.save()
 
     def save(self):
@@ -194,6 +210,7 @@ class ParticleSwarmOptimization(BaseOptimizer):
         with open(self.swarm_path, 'rb') as file:
             data = pickle.load( file )
         self.swarm, self.best, self.best_score = data
+        print( self.summary() )
 
     def clear_scores(self):
         try:
@@ -206,4 +223,33 @@ class ParticleSwarmOptimization(BaseOptimizer):
                 entry.best_score = float('-inf')
             self.save()
             print("Removed scores from Particle Swarm.")
+
+    def summary(self):
+        swarm = [p for p in self.swarm if p.age > 0]
+        s  = "Number of particles %d\n"%len(swarm)
+        s += "Number of evaluations %d\n"%sum(p.age for p in swarm)
+        if not swarm:
+            return s
+        # Print statistical summary of swarm.
+        best = [p.best_score for p in swarm if p.best_score is not None]
+        s += ("Best score Min/Mean/Std/Max %g / %g / %g / %g\n"%
+                            (min(best), np.mean(best), np.std(best), max(best)))
+        str_len = max( len(p) for p in swarm[0].parameters.enumerate() )
+        s += "\nParameters, Min/Mean/Std/Max:\n"
+        for path in swarm[0].parameters.enumerate():
+            data = []
+            for p in swarm:
+                data.append( p.parameters.get( path ) )
+            s += path.ljust(str_len) + "\t%g / %g / %g / %g\n"%( # TODO: Center these data fields...
+                                min(data), np.mean(data), np.std(data), max(data))
+        s += "\nVelocities, Min/Mean/Std/Max:\n"
+        for path in swarm[0].parameters.enumerate():
+            data = []
+            for p in swarm:
+                data.append( p.velocities.get( path ) )
+            s += path.ljust(str_len) + "\t%g / %g / %g / %g\n"%( # TODO: Center these data fields...
+                                min(data), np.mean(data), np.std(data), max(data))
+
+        s += "\n\nBest Parameters " + str(self.best)
+        return s
 

--- a/src/nupic/engine/Region.cpp
+++ b/src/nupic/engine/Region.cpp
@@ -501,7 +501,7 @@ bool Region::operator==(const Region &o) const {
                   compareInput)) {
     return false;
   }
-  // Compare Regions's Output (checking only output buffer names and type.)
+  // Compare Regions's Output
   static auto compareOutput = [](decltype(*outputs_.begin()) a, decltype(*outputs_.begin()) b) {
     if (a.first != b.first ) {
       return false;
@@ -512,12 +512,17 @@ bool Region::operator==(const Region &o) const {
     if (output_a->getData().getType() != output_b->getData().getType() ||
         output_a->getData().getCount() != output_b->getData().getCount())
         return false;
+    // compare output buffer contents.
+    if (output_a->getData() != output_b->getData()) return false;
     return true;
   };
-  if (!std::equal(outputs_.begin(), outputs_.end(), o.outputs_.begin(),
-                  compareOutput)) {
+  if (!std::equal(outputs_.begin(), outputs_.end(), o.outputs_.begin(), compareOutput)) {
     return false;
   }
+
+  if (impl_ && !o.impl_) return false;
+  if (!impl_ && o.impl_) return false;
+  if (impl_ && *impl_.get() != *o.impl_.get()) return false;
 
   return true;
 }

--- a/src/nupic/engine/Region.hpp
+++ b/src/nupic/engine/Region.hpp
@@ -464,6 +464,7 @@ public:
        cereal::make_nvp("nodeType", type_),
        cereal::make_nvp("initialized", initialized_),
        cereal::make_nvp("phases", phases_));
+    ar(cereal::make_nvp("dim", getDimensions()));
 
     std::map<std::string, Dimensions> outDims;
     std::map<std::string, Dimensions> inDims;
@@ -487,10 +488,13 @@ public:
   //       before deserializing a region.
   template<class Archive>
   void load_ar(Archive& ar) {
+    Dimensions dim;
+    bool init;
     ar(cereal::make_nvp("name", name_));
     ar(cereal::make_nvp("nodeType", type_));
-    ar(cereal::make_nvp("initialized", initialized_));
+    ar(cereal::make_nvp("initialized", init));
     ar(cereal::make_nvp("phases", phases_));
+    ar(cereal::make_nvp("dim", dim));
 
     std::map<std::string, Dimensions> outDims;
     std::map<std::string, Dimensions> inDims;
@@ -506,6 +510,11 @@ public:
     // deserialize the RegionImpl plugin and its algorithm
     ArWrapper arw(&ar);
     deserializeImpl(arw);
+
+    // set the region dimensions.
+    initialized_ = false; // setDimensions requires initialization off.
+    setDimensions(dim);
+    initialized_ = init;
   }
 
   friend class Network;  // so Network can set Network* network_; during addRegion( ).

--- a/src/nupic/engine/RegionImpl.hpp
+++ b/src/nupic/engine/RegionImpl.hpp
@@ -228,6 +228,12 @@ public:
   virtual void cereal_adapter_save(ArWrapper& a) const {};
   virtual void cereal_adapter_load(ArWrapper& a) {};
 
+  virtual bool operator==(const RegionImpl &other) const = 0;
+  virtual inline bool operator!=(const RegionImpl &other) const {
+    return !operator==(other);
+  }
+
+
   /**
     * Inputs/Outputs are made available in initialize()
     * It is always called after the constructor (or load from serialized state)

--- a/src/nupic/regions/SPRegion.cpp
+++ b/src/nupic/regions/SPRegion.cpp
@@ -997,4 +997,33 @@ void SPRegion::deserialize(BundleIO &bundle) {
     sp_ = nullptr;
 }
 
+bool SPRegion::operator==(const RegionImpl &o) const {
+  if (o.getType() != "SPRegion") return false;
+  SPRegion& other = (SPRegion&)o;
+  if (args_.inputWidth != other.args_.inputWidth) return false;
+  if (args_.columnCount != other.args_.columnCount) return false;
+  if (args_.potentialRadius != other.args_.potentialRadius) return false;
+  if (args_.potentialPct != other.args_.potentialPct) return false;
+  if (args_.globalInhibition != other.args_.globalInhibition) return false;
+  if (args_.localAreaDensity != other.args_.localAreaDensity) return false;
+  if (args_.numActiveColumnsPerInhArea != other.args_.numActiveColumnsPerInhArea) return false;
+  if (args_.stimulusThreshold != other.args_.stimulusThreshold) return false;
+  if (args_.synPermInactiveDec != other.args_.synPermInactiveDec) return false;
+  if (args_.synPermActiveInc != other.args_.synPermActiveInc) return false;
+  if (args_.synPermConnected != other.args_.synPermConnected) return false;
+  if (args_.minPctOverlapDutyCycles != other.args_.minPctOverlapDutyCycles) return false;
+  if (args_.dutyCyclePeriod != other.args_.dutyCyclePeriod) return false;
+  if (args_.boostStrength != other.args_.boostStrength) return false;
+  if (args_.seed != other.args_.seed) return false;
+  if (args_.spVerbosity != other.args_.spVerbosity) return false;
+  if (args_.wrapAround != other.args_.wrapAround) return false;
+  if (args_.learningMode != other.args_.learningMode) return false;
+
+  if (dim_ != other.dim_) return false;  // from RegionImpl
+  if ((sp_ && !other.sp_) || (other.sp_ && !sp_)) return false;
+  if (sp_ && (*sp_ != *other.sp_)) return false;
+
+  return true;
+}
+
 } // namespace nupic

--- a/src/nupic/regions/SPRegion.hpp
+++ b/src/nupic/regions/SPRegion.hpp
@@ -96,7 +96,6 @@ class SPRegion  : public RegionImpl, Serializable
 	    ar(cereal::make_nvp("spVerbosity", args_.spVerbosity));
 	    ar(cereal::make_nvp("wrapAround", args_.wrapAround));
 	    ar(cereal::make_nvp("learningMode", args_.learningMode));
-			ar(cereal::make_nvp("dim", dim_));  // from RegionImpl
 	    ar(cereal::make_nvp("init", init));
 	    if (init) {
         // Save the algorithm state
@@ -126,7 +125,6 @@ class SPRegion  : public RegionImpl, Serializable
 	    ar(cereal::make_nvp("spVerbosity", args_.spVerbosity));
 	    ar(cereal::make_nvp("wrapAround", args_.wrapAround));
 	    ar(cereal::make_nvp("learningMode", args_.learningMode));
-			ar(cereal::make_nvp("dim", dim_));  // from RegionImpl
 	    ar(cereal::make_nvp("init", init));
 	    if (init) {
 	      // Restore algorithm state
@@ -136,6 +134,11 @@ class SPRegion  : public RegionImpl, Serializable
 	    }
 	  }
 
+
+    bool operator==(const RegionImpl &other) const override;
+    inline bool operator!=(const SPRegion &other) const {
+      return !operator==(other);
+    }
 
 
     // Per-node size (in elements) of the given output.

--- a/src/nupic/regions/ScalarSensor.cpp
+++ b/src/nupic/regions/ScalarSensor.cpp
@@ -264,5 +264,22 @@ void ScalarSensor::deserialize(BundleIO &bundle) {
   initialize();
 }
 
+bool ScalarSensor::operator==(const RegionImpl &o) const {
+  if (o.getType() != "ScalarSensor") return false;
+  ScalarSensor& other = (ScalarSensor&)o;
+  if (params_.minimum != other.params_.minimum) return false;
+  if (params_.maximum != other.params_.maximum) return false;
+  if (params_.clipInput != other.params_.clipInput) return false;
+  if (params_.periodic != other.params_.periodic) return false;
+  if (params_.activeBits != other.params_.activeBits) return false;
+  if (params_.sparsity != other.params_.sparsity) return false;
+  if (params_.size != other.params_.size) return false;
+  if (params_.radius != other.params_.radius) return false;
+  if (params_.resolution != other.params_.resolution) return false;
+  if (sensedValue_ != other.sensedValue_) return false;
+
+  return true;
+}
+
 
 } // namespace nupic

--- a/src/nupic/regions/ScalarSensor.hpp
+++ b/src/nupic/regions/ScalarSensor.hpp
@@ -84,7 +84,6 @@ public:
        cereal::make_nvp("radius", params_.radius),
        cereal::make_nvp("resolution", params_.resolution),
        cereal::make_nvp("sensedValue_", sensedValue_));
-    // TODO:cereal   Also serialize the outputs
   }
   // FOR Cereal Deserialization
   // NOTE: the Region Implementation must have been allocated
@@ -108,6 +107,11 @@ public:
     setDimensions(encoder_->dimensions); 
   }
 
+
+  bool operator==(const RegionImpl &other) const override;
+  inline bool operator!=(const ScalarSensor &other) const {
+    return !operator==(other);
+  }
 
 private:
   Real64 sensedValue_;

--- a/src/nupic/regions/TMRegion.cpp
+++ b/src/nupic/regions/TMRegion.cpp
@@ -920,3 +920,32 @@ void TMRegion::deserialize(BundleIO &bundle) {
   f.ignore(1);
 }
 
+bool TMRegion::operator==(const RegionImpl &o) const {
+  if (o.getType() != "TMRegion") return false;
+  TMRegion& other = (TMRegion&)o;
+  if (args_.numberOfCols != other.args_.numberOfCols) return false;
+  if (args_.cellsPerColumn != other.args_.cellsPerColumn) return false;
+  if (args_.activationThreshold != other.args_.activationThreshold) return false;
+  if (args_.initialPermanence != other.args_.initialPermanence) return false;
+  if (args_.connectedPermanence != other.args_.connectedPermanence) return false;
+  if (args_.maxNewSynapseCount != other.args_.maxNewSynapseCount) return false;
+  if (args_.permanenceIncrement != other.args_.permanenceIncrement) return false;
+  if (args_.permanenceDecrement != other.args_.permanenceDecrement) return false;
+  if (args_.predictedSegmentDecrement != other.args_.predictedSegmentDecrement) return false;
+  if (args_.seed != other.args_.seed) return false;
+  if (args_.maxSegmentsPerCell != other.args_.maxSegmentsPerCell) return false;
+  if (args_.maxSynapsesPerSegment != other.args_.maxSynapsesPerSegment) return false;
+  if (args_.extra != other.args_.extra) return false;
+  if (args_.checkInputs != other.args_.checkInputs) return false;
+  if (args_.learningMode != other.args_.learningMode) return false;
+  if (args_.sequencePos != other.args_.sequencePos) return false;
+  if (args_.iter != other.args_.iter) return false;
+  if (args_.orColumnOutputs != other.args_.orColumnOutputs) return false;
+  if (dim_ != other.dim_) return false;  // from RegionImpl
+  if ((tm_ && !other.tm_) || (other.tm_ && !tm_)) return false;
+  if (tm_ && (*tm_ != *other.tm_)) return false;
+
+  return true;
+}
+
+

--- a/src/nupic/regions/TMRegion.hpp
+++ b/src/nupic/regions/TMRegion.hpp
@@ -93,7 +93,6 @@ public:
     ar(cereal::make_nvp("sequencePos", args_.sequencePos));
     ar(cereal::make_nvp("iter", args_.iter));
     ar(cereal::make_nvp("orColumnOutputs", args_.orColumnOutputs));
-    ar(cereal::make_nvp("dim", dim_));  // from RegionImpl
     ar(cereal::make_nvp("init", init));
     if (init) {
       // Save the algorithm state
@@ -123,7 +122,6 @@ public:
     ar(cereal::make_nvp("sequencePos", args_.sequencePos));
     ar(cereal::make_nvp("iter", args_.iter));
     ar(cereal::make_nvp("orColumnOutputs", args_.orColumnOutputs));
-    ar(cereal::make_nvp("dim", dim_));  // from RegionImpl
     ar(cereal::make_nvp("init", init));
 
     args_.outputWidth = (args_.orColumnOutputs)?args_.numberOfCols
@@ -134,7 +132,10 @@ public:
     }
   }
 
-
+  bool operator==(const RegionImpl &other) const override;
+  inline bool operator!=(const TMRegion &other) const {
+    return !operator==(other);
+  }
 
   // Per-node size (in elements) of the given output.
   // For per-region outputs, it is the total element count.

--- a/src/nupic/regions/TestNode.cpp
+++ b/src/nupic/regions/TestNode.cpp
@@ -744,4 +744,64 @@ void TestNode::deserialize(BundleIO &bundle) {
   }
 
 
+  bool TestNode::operator==(const RegionImpl &o) const {
+    if (o.getType() != "TestNode") return false;
+    TestNode& other = (TestNode&)o;
+    if (nodeCount_ != other.nodeCount_) return false;
+    if (int32Param_ != other.int32Param_) return false;
+    if (uint32Param_ != other.uint32Param_) return false;
+    if (int64Param_ != other.int64Param_) return false;
+    if (uint64Param_ != other.uint64Param_) return false;
+    if (real32Param_ != other.real32Param_) return false;
+    if (real64Param_ != other.real64Param_) return false;
+    if (boolParam_ != other.boolParam_) return false;
+    if (stringParam_ != other.stringParam_) return false;
+    if (outputElementCount_ != other.outputElementCount_) return false;
+    if (delta_ != other.delta_) return false;
+    if (iter_ != other.iter_) return false;
+    if (dim_ != other.dim_) return false;
+
+    if (unclonedParam_.size() != other.unclonedParam_.size()) return false;
+    for (size_t i = 0; i < unclonedParam_.size(); i++) {
+      if (unclonedParam_[i] != other.unclonedParam_[i]) return false;
+    }
+
+    if (real32ArrayParam_.size() != other.real32ArrayParam_.size()) return false;
+    for (size_t i = 0; i < real32ArrayParam_.size(); i++) {
+      if (real32ArrayParam_[i] != other.real32ArrayParam_[i]) return false;
+    }
+
+    if (int64ArrayParam_.size() != other.int64ArrayParam_.size()) return false;
+    for (size_t i = 0; i < int64ArrayParam_.size(); i++) {
+      if (int64ArrayParam_[i] != other.int64ArrayParam_[i]) return false;
+    }
+
+
+    if (boolArrayParam_.size() != other.boolArrayParam_.size()) return false;
+    for (size_t i = 0; i < boolArrayParam_.size(); i++) {
+      if (boolArrayParam_[i] != other.boolArrayParam_[i]) return false;
+    }
+
+    if (shouldCloneParam_ != other.shouldCloneParam_) return false;
+    if (possiblyUnclonedParam_.size() != other.possiblyUnclonedParam_.size()) return false;
+    for (size_t i = 0; i < possiblyUnclonedParam_.size(); i++) {
+      if (possiblyUnclonedParam_[i] != other.possiblyUnclonedParam_[i]) return false;
+    }
+
+    if (unclonedInt64ArrayParam_.size() != other.unclonedInt64ArrayParam_.size()) return false;
+    for (size_t i = 0; i < unclonedInt64ArrayParam_.size(); i++)
+    {
+      if (unclonedInt64ArrayParam_[i].size() != other.unclonedInt64ArrayParam_[i].size())
+        return false;
+      for (size_t j = 0; j < unclonedInt64ArrayParam_[i].size(); j++) {
+        if (unclonedInt64ArrayParam_[i][j] != other.unclonedInt64ArrayParam_[i][j])
+          return false;
+      }
+    }
+
+    return true;
+  }
+
+
+
 } // namespace nupic

--- a/src/nupic/regions/TestNode.hpp
+++ b/src/nupic/regions/TestNode.hpp
@@ -94,6 +94,7 @@ public:
        CEREAL_NVP(real32Param_),
        CEREAL_NVP(real64Param_),
        CEREAL_NVP(boolParam_),
+       CEREAL_NVP(stringParam_),
        CEREAL_NVP(outputElementCount_),
        CEREAL_NVP(delta_),
        CEREAL_NVP(iter_));
@@ -104,6 +105,7 @@ public:
        CEREAL_NVP(boolArrayParam_),
        CEREAL_NVP(unclonedParam_),
        CEREAL_NVP(shouldCloneParam_),
+       CEREAL_NVP(possiblyUnclonedParam_),
        CEREAL_NVP(unclonedInt64ArrayParam_));
   }
   // FOR Cereal Deserialization
@@ -121,6 +123,7 @@ public:
        CEREAL_NVP(real32Param_),
        CEREAL_NVP(real64Param_),
        CEREAL_NVP(boolParam_),
+       CEREAL_NVP(stringParam_),
        CEREAL_NVP(outputElementCount_),
        CEREAL_NVP(delta_),
        CEREAL_NVP(iter_));
@@ -131,7 +134,13 @@ public:
        CEREAL_NVP(boolArrayParam_),
        CEREAL_NVP(unclonedParam_),
        CEREAL_NVP(shouldCloneParam_),
+       CEREAL_NVP(possiblyUnclonedParam_),
        CEREAL_NVP(unclonedInt64ArrayParam_));
+  }
+
+  bool operator==(const RegionImpl &other) const override;
+  inline bool operator!=(const TestNode &other) const {
+    return !operator==(other);
   }
 
 

--- a/src/nupic/regions/VectorFileEffector.hpp
+++ b/src/nupic/regions/VectorFileEffector.hpp
@@ -34,6 +34,7 @@
 #include <nupic/engine/RegionImpl.hpp>
 #include <nupic/ntypes/Array.hpp>
 #include <nupic/types/Types.hpp>
+#include <nupic/types/Serializable.hpp>
 
 namespace nupic {
 
@@ -71,9 +72,7 @@ public:
   VectorFileEffector(const ValueMap &params, Region *region);
 
   VectorFileEffector(BundleIO &bundle, Region *region);
-  VectorFileEffector(ArWrapper& wrapper, Region *region) : RegionImpl(region) {
-    // TODO:cereal  complete.
-  }
+  VectorFileEffector(ArWrapper& wrapper, Region *region);
 
   virtual ~VectorFileEffector();
 
@@ -86,6 +85,29 @@ public:
   /// De-serialize state from bundle
   // ---
   virtual void deserialize(BundleIO &bundle) override;
+	
+
+	CerealAdapter;  // see Serializable.hpp
+  // FOR Cereal Serialization
+  template<class Archive>
+  void save_ar(Archive& ar) const {
+    ar(cereal::make_nvp("outputFile", filename_));
+    ar(CEREAL_NVP(dim_));  // in base class
+  }
+
+  // FOR Cereal Deserialization
+  template<class Archive>
+  void load_ar(Archive& ar) {
+    ar(cereal::make_nvp("outputFile", filename_));
+		if (filename_ != "")
+		      openFile(filename_);
+    ar(CEREAL_NVP(dim_));  // in base class
+  }	
+
+  bool operator==(const RegionImpl &other) const override;
+  inline bool operator!=(const VectorFileEffector &other) const {
+    return !operator==(other);
+  }
 
 
   void compute() override;

--- a/src/nupic/regions/VectorFileSensor.cpp
+++ b/src/nupic/regions/VectorFileSensor.cpp
@@ -49,25 +49,37 @@ namespace nupic {
 VectorFileSensor::VectorFileSensor(const ValueMap &params, Region *region)
     : RegionImpl(region),
 
-      iterations_(0), curVector_(0),
+      iterations_(0), curVector_(-1),
       dataOut_(NTA_BasicType_Real32), categoryOut_(NTA_BasicType_Real32),
-      resetOut_(NTA_BasicType_Real32), filename_(""), scalingMode_("none"),
+      resetOut_(NTA_BasicType_Real32), filename_(""),
       recentFile_("") {
   repeatCount_ = params.getScalarT<UInt32>("repeatCount", 1);
   activeOutputCount_ = params.getScalarT<UInt32>("activeOutputCount", 0);
   hasCategoryOut_ = params.getScalarT<UInt32>("hasCategoryOut", 0) == 1;
   hasResetOut_ = params.getScalarT<UInt32>("hasResetOut", 0) == 1;
+  scalingMode_ = params.getString("scalingMode");
+  if (scalingMode_ != "standardForm")
+    scalingMode_ = "none";
+
   if (params.contains("inputFile"))
     filename_ = params.getString("inputFile");
 }
 
 VectorFileSensor::VectorFileSensor(BundleIO &bundle, Region *region)
-    : RegionImpl(region), repeatCount_(1), iterations_(0), curVector_(0),
+    : RegionImpl(region), repeatCount_(1), iterations_(0), curVector_(-1),
       activeOutputCount_(0), hasCategoryOut_(false), hasResetOut_(false),
       dataOut_(NTA_BasicType_Real32), categoryOut_(NTA_BasicType_Real32),
       resetOut_(NTA_BasicType_Real32), filename_(""), scalingMode_("none"),
       recentFile_("") {
   deserialize(bundle);
+}
+VectorFileSensor::VectorFileSensor(ArWrapper& wrapper, Region *region) 
+    : RegionImpl(region), repeatCount_(1), iterations_(0), curVector_(-1),
+      activeOutputCount_(0), hasCategoryOut_(false), hasResetOut_(false),
+      dataOut_(NTA_BasicType_Real32), categoryOut_(NTA_BasicType_Real32),
+      resetOut_(NTA_BasicType_Real32), filename_(""), scalingMode_("none"),
+      recentFile_("") {
+  cereal_adapter_load(wrapper);
 }
 
 
@@ -123,7 +135,7 @@ void VectorFileSensor::compute() {
     Real *categoryOut = reinterpret_cast<Real *>(categoryOut_.getBuffer());
     vectorFile_.getRawVector((nupic::UInt)curVector_, categoryOut, offset, 1);
     offset++;
-    NTA_DEBUG << "compute " << *region_->getOutput("categoryOut") << "\n";
+    NTA_DEBUG << "VectorFileSensor compute() CategoryOut= " << *region_->getOutput("categoryOut") << "\n";
   }
 
   if (hasResetOut_) {
@@ -131,11 +143,11 @@ void VectorFileSensor::compute() {
     Real *resetOut = reinterpret_cast<Real *>(resetOut_.getBuffer());
     vectorFile_.getRawVector((nupic::UInt)curVector_, resetOut, offset, 1);
     offset++;
-    NTA_DEBUG << "compute " << *region_->getOutput("reset") << "\n";
+    NTA_DEBUG << "VectorFileSensor compute() reset= " << *region_->getOutput("reset") << "\n";
   }
 
   vectorFile_.getScaledVector((nupic::UInt)curVector_, out, offset, count);
-  NTA_DEBUG << "compute " << *region_->getOutput("dataOut") << "\n";
+  NTA_DEBUG << "VectorFileSensor compute() dataOut= " << *region_->getOutput("dataOut") << "\n";
   iterations_++;
 }
 
@@ -200,6 +212,12 @@ std::string VectorFileSensor::executeCommand(const std::vector<std::string>& arg
     if (command == "loadFile")
       vectorFile_.clear(false);
 
+    if (activeOutputCount_ == 0) { 
+      // vector width not specified so use the region dimensions.
+      activeOutputCount_ = static_cast<UInt32>(dim_.getCount());
+    }
+
+
     // Timer t(true);
 
     UInt32 elementCount = activeOutputCount_;
@@ -210,23 +228,28 @@ std::string VectorFileSensor::executeCommand(const std::vector<std::string>& arg
 
     vectorFile_.appendFile(filename, elementCount, labeled);
     cout << "Read " << vectorFile_.vectorCount() << " vectors" << endl;
-    // in " << t.getValue() << " seconds" << endl;
+    // << "  in " << t.getValue() << " seconds" << endl;
+
+    vectorFile_.resetScaling(activeOutputCount_); // clear scaling
+    if (scalingMode_ == "standardForm")
+      vectorFile_.setStandardScaling();
 
     if (command == "loadFile")
       seek(0);
+
 
     recentFile_ = filename;
   }
 
   else if (command == "dump") {
-    char message[256];
-    Size n = ::sprintf(message,
-                       "VectorFileSensor isLabeled = %d repeatCount = %d "
-                       "vectorCount = %d iterations = %d\n",
-                       vectorFile_.isLabeled(), (int)repeatCount_,
-                       (int)vectorFile_.vectorCount(), (int)iterations_);
-    // out.write(message, n);
-    return string(message, n);
+    std::string message;
+    message = "VectorFileSensor isLabeled = " + to_string(vectorFile_.isLabeled())
+      + ", repeatCount = " + to_string(repeatCount_)
+      + ", vectorWidth = " + to_string(vectorFile_.getElementCount())
+      + ", vectorCount = " + to_string(vectorFile_.vectorCount())
+      + ", iterations = " + to_string(iterations_)
+      + "\n";
+    return message;
   }
 
   else if (command == "saveFile") {
@@ -257,10 +280,9 @@ std::string VectorFileSensor::executeCommand(const std::vector<std::string>& arg
     NTA_CHECK(argCount <= 5) << "VectorFileSensor: too many arguments";
 
     std::ofstream f(filename.c_str());
-    if (hasEnd)
-      vectorFile_.saveVectors(f, dataOut_.getCount(), format, begin, end);
-    else
-      vectorFile_.saveVectors(f, dataOut_.getCount(), format, begin, end);
+    if (!hasEnd)
+      end = vectorFile_.vectorCount() - 1;
+    vectorFile_.saveVectors(f, dataOut_.getCount(), format, begin, end);
   }
 
   else {
@@ -272,75 +294,27 @@ std::string VectorFileSensor::executeCommand(const std::vector<std::string>& arg
 }
 
 //----------------------------------------------------------------------
+/**
+ * Position to a vector within the vector file.
+ * A negative number for n will position n from the end (wrapping backward). 
+ */
 void VectorFileSensor::seek(int n) {
-  NTA_CHECK((n >= 0) && ((unsigned int)n < vectorFile_.vectorCount()));
-
   // Set curVector_ to be one before the vector we want and reset iterations
+  // On the next compute() it will advance to the vector we want and output it.
   iterations_ = 0;
   curVector_ = n - 1;
-  // circular-buffer, reached one end of vector/line, continue fro the other
-  if (n - 1 <= 0)
-    curVector_ = static_cast<UInt32>(vectorFile_.vectorCount() - 1);
+
+  // circular-buffer, reached one end of vector/line, wrap around.
+  if (curVector_ < 0) // make n >= 0.
+    curVector_ += static_cast<int>(vectorFile_.vectorCount()); 
+  NTA_ASSERT(curVector_ >= 0);
+  curVector_ %= vectorFile_.vectorCount();
 }
 
 size_t
 VectorFileSensor::getNodeOutputElementCount(const std::string &outputName) const {
   NTA_CHECK(outputName == "dataOut") << "Invalid output name: " << outputName;
   return activeOutputCount_;
-}
-
-void VectorFileSensor::serialize(BundleIO &bundle) {
-  std::ostream & f = bundle.getOutputStream();
-  f << repeatCount_ << " " << activeOutputCount_ << " " << curVector_ << " "
-    << iterations_ << " " << hasCategoryOut_ << " " << hasResetOut_ << " "
-    << ((filename_ == "")?std::string("empty"):filename_) << " "
-    << ((scalingMode_ == "")?std::string("empty"):scalingMode_) << " "
-    << ((recentFile_ == "")?std::string("empty"):recentFile_) << std::endl;
-  f << "outputs [";
-  std::map<std::string, Output *> outputs = region_->getOutputs();
-  for (auto iter : outputs) {
-    const Array &outputBuffer = iter.second->getData();
-    if (outputBuffer.getCount() != 0) {
-      f << iter.first << " ";
-      outputBuffer.save(f);
-    }
-  }
-  f << "] "; // end of all output buffers
-  
-  f << "[" << std::endl;
-  vectorFile_.save(f);
-  f << "]" << std::endl;
-  f.flush();
-}
-
-void VectorFileSensor::deserialize(BundleIO &bundle) {
-  std::istream& f = bundle.getInputStream();
-  std::string tag;
-  f >> repeatCount_ >> activeOutputCount_ >> curVector_ >> iterations_ >>
-      hasCategoryOut_ >> hasResetOut_;
-  f >>  filename_ >> scalingMode_ >> recentFile_;
-  if (filename_ == "empty") filename_ = "";
-  if (scalingMode_ == "empty") scalingMode_ = "";
-  if (recentFile_ == "empty") recentFile_ = "";
-  f >> tag;
-  NTA_CHECK(tag == "outputs");
-  f.ignore(1);
-  NTA_CHECK(f.get() == '['); // start of outputs
-  while (true) {
-    f >> tag;
-    f.ignore(1);
-    if (tag == "]")
-      break;
-    Array& a = getOutput(tag)->getData();
-    a.load(f);
-  }
-  f >> tag;
-  NTA_CHECK(tag == "[");
-  f.ignore(1);
-  vectorFile_.load(f);
-  f >> tag;
-  NTA_CHECK(tag == "]") << "Expected the end of vectorFile.load";
-  f.ignore(1);
 }
 
 
@@ -392,19 +366,19 @@ Spec *VectorFileSensor::createSpec() {
                              ));
 
   ns->outputs.add( "categoryOut",
-				  OutputSpec("The current category encoded as a float (represent a whole number)",
-					         NTA_BasicType_Real32,
-					         1,    // count
-					         true, // isRegionLevel
-					         false // isDefaultOutput
-					         ));
+				          OutputSpec("The current category encoded as a float (represent a whole number)",
+					                 NTA_BasicType_Real32,
+					                 1,    // count
+					                 false, // isRegionLevel
+					                 false // isDefaultOutput
+					                 ));
 
   ns->outputs.add("resetOut",
                   OutputSpec("Sequence reset signal: 0 - do nothing, otherwise "
                              "start a new sequence",
                              NTA_BasicType_Real32,
                              1,    // count
-                             true, // isRegionLevel
+                             false, // isRegionLevel
                              false // isDefaultOutput
                              ));
 
@@ -418,11 +392,16 @@ Spec *VectorFileSensor::createSpec() {
 
   ns->parameters.add("position",
                    ParameterSpec("Set or get the current position within the "
-                             "list of vectors in memory.",
-                             NTA_BasicType_UInt32,
+                             "list of vectors in memory. Index of vector last output. "
+                             "Before anything is output, position is -1. Setting a position "
+                             "will position just prior to the requested vector so that "
+                             "the requested value will be the next output from the next "
+                             "call to compute(). If the requested position is outside the "
+                             "range of the vector set, it will wrap to be inside the range.",
+                             NTA_BasicType_Int32,
                              1,                    // elementCount
                              "interval: [0, ...]", // constraints
-                             "0",                  // defaultValue
+                             "-1",                  // defaultValue (before first value).
                              ParameterSpec::ReadWriteAccess));
 
   ns->parameters.add( "repeatCount",
@@ -518,30 +497,24 @@ Spec *VectorFileSensor::createSpec() {
 
   ns->commands.add( "loadFile",
       CommandSpec(
-          "loadFile <filename> [file_format]\n"
-          "Reads vectors from the specified file, replacing any vectors\n"
-          "currently in the list. Position is set to zero. \n"
-          "Available file formats are: \n"
-          "       0        # Reads in unlabeled file with first number = "
-          "element count\n"
-          "       1        # Reads in a labeled file with first number = "
-          "element count (deprecated)\n"
-          "       2        # Reads in unlabeled file without element count "
-          "(default)\n"
-          "       3        # Reads in a csv file\n"));
+        "loadFile <filename> [file_format]\n"
+        "Reads vectors from the specified file, replacing any vectors\n"
+        "currently in the list. Position is set to zero. \n"
+        "Available file formats are: \n"
+        " 0 - Reads in unlabeled file with first number = element count\n"
+        " 1 - Reads in a labeled file with first number = element count (deprecated)\n"
+        " 2 - Reads in unlabeled file without element count (default)\n"
+        " 3 - Reads in a csv file\n"));
 
   ns->commands.add( "appendFile",
-      CommandSpec("appendFile <filename> [file_format]\n"
-                  "Reads vectors from the specified file, appending to current "
-                  "vector list.\n"
-                  "Position remains unchanged. Available file formats are: \n"
-                  "       0        # Reads in unlabeled file with first number "
-                  "= element count\n"
-                  "       1        # Reads in a labeled file with first number "
-                  "= element count (deprecated)\n"
-                  "       2        # Reads in unlabeled file without element "
-                  "count (default)\n"
-                  "       3        # Reads in a csv file\n"));
+      CommandSpec(
+        "appendFile <filename> [file_format]\n"
+        "Reads vectors from the specified file, appending to current vector list.\n"
+        "Position remains unchanged. Available file formats are: \n"
+        " 0 - Reads in unlabeled file with first number = element count\n"
+        " 1 - Reads in a labeled file with first number = element count (deprecated)\n"
+        " 2 - Reads in unlabeled file without element count (default)\n"
+        " 3 - Reads in a csv file\n"));
 
   ns->commands.add( "saveFile",
        CommandSpec("saveFile filename [format [begin [end]]]\n"
@@ -560,8 +533,6 @@ Spec *VectorFileSensor::createSpec() {
 UInt32 VectorFileSensor::getParameterUInt32(const std::string &name, Int64 index) {
   if (name == "vectorCount") {
     return (UInt32)vectorFile_.vectorCount();
-  } else if (name == "position") {
-    return curVector_ + 1;
   } else if (name == "repeatCount") {
     return repeatCount_;
   } else if (name == "activeOutputCount") {
@@ -577,6 +548,14 @@ UInt32 VectorFileSensor::getParameterUInt32(const std::string &name, Int64 index
   }
 }
 
+Int32 VectorFileSensor::getParameterInt32(const std::string &name, Int64 index) {
+  if (name == "position") {
+    if (vectorFile_.vectorCount() == 0) return -1;
+    return curVector_;
+  } else {
+    return RegionImpl::getParameterInt32(name, index);
+  }
+}
 std::string VectorFileSensor::getParameterString(const std::string &name, Int64 index) {
   if (name == "scalingMode") {
     return scalingMode_;
@@ -617,24 +596,11 @@ void VectorFileSensor::setParameterUInt32(const std::string &name, Int64 index, 
   const char *where = "setParameterUInt32() VectorFileSensor, parameter ";
 
   if (name == "repeatCount") {
-    NTA_CHECK(value == 0)
+    NTA_CHECK(value > 0)
         << where << "repeatCount: " << value
-        << " - Should be a positive integer";
+        << " - Should be a positive non-zero integer";
 
-    if (value >= 1) {
-    	repeatCount_ = value;
-	}
-  }
-  else if (name == "position") {
-    NTA_CHECK(value == 0)
-        << where << "position: " << value
-        << " - Should be a positive integer";
-    if (value < vectorFile_.vectorCount()) {
-      seek(value);
-    } else {
-      NTA_THROW << where << "position: invalid position "
-                << " to seek to: " << value;
-    }
+    repeatCount_ = value;
   }
   else if (name == "hasCategoryOut") {
     hasCategoryOut_ = (value == 1);
@@ -643,6 +609,19 @@ void VectorFileSensor::setParameterUInt32(const std::string &name, Int64 index, 
     hasResetOut_ = (value == 1);
   } else {
 	RegionImpl::setParameterUInt32(name, index, value);
+  }
+}
+
+void VectorFileSensor::setParameterInt32(const std::string &name, Int64 index, Int32 value) {
+  const char *where = "setParameterInt32() VectorFileSensor, parameter ";
+  if (name == "position") {
+    if (vectorFile_.vectorCount() == 0) return; // not yet initialized.
+    NTA_CHECK(value >= 0 && value < static_cast<Int32>(vectorFile_.vectorCount()))
+      << where << "'position'." << " Requested position is out of range. [ 0 to "
+      << (vectorFile_.vectorCount() - 1) << "]";
+    seek(value);
+  } else {
+	  RegionImpl::setParameterInt32(name, index, value);
   }
 }
 
@@ -657,7 +636,7 @@ void VectorFileSensor::setParameterString(const std::string &name, Int64 index, 
       NTA_THROW << where << " Unknown scaling mode: " << value;
     scalingMode_ = value;
   } else {
-	RegionImpl::setParameterString(name, index, value);
+	  RegionImpl::setParameterString(name, index, value);
   }
 }
 
@@ -665,9 +644,9 @@ void VectorFileSensor::setParameterString(const std::string &name, Int64 index, 
 
 void VectorFileSensor::setParameterArray(const std::string &name, Int64 index,
                                          const Array &a) {
-  if (a.getCount() != dataOut_.getCount())
-    NTA_THROW << "setParameterArray(), array size is: " << a.getCount()
-              << "instead of : " << dataOut_.getCount();
+  NTA_CHECK (a.getCount() == dataOut_.getCount())
+         << "setParameterArray(), array size is: " << a.getCount()
+         << "instead of : " << dataOut_.getCount();
 
   Real *buf = (Real *)a.getBuffer();
   if (name == "scaleVector") {
@@ -680,20 +659,89 @@ void VectorFileSensor::setParameterArray(const std::string &name, Int64 index,
       vectorFile_.setOffset(i, buf[i]);
     }
   } else {
-    NTA_THROW << "VectorfileSensor::setParameterArray(), unknown parameter: "
-              << name;
+    NTA_THROW << "VectorfileSensor::setParameterArray(), unknown parameter: " << name;
   }
 
   scalingMode_ = "custom";
 }
 
 size_t VectorFileSensor::getParameterArrayCount(const std::string &name, Int64 index) {
-  if (name != "scaleVector" && name != "offsetVector")
-    NTA_THROW << "VectorFileSensor::getParameterArrayCount(), unknown array "
-                 "parameter: "
-              << name;
-
+  NTA_CHECK (name == "scaleVector" || name == "offsetVector")
+     << "VectorFileSensor::getParameterArrayCount(), unknown array parameter: "<< name;
   return dataOut_.getCount();
+}
+
+
+
+void VectorFileSensor::serialize(BundleIO &bundle) {
+  std::ostream & f = bundle.getOutputStream();
+  f << repeatCount_ << " " << activeOutputCount_ << " " << curVector_ << " "
+    << iterations_ << " " << hasCategoryOut_ << " " << hasResetOut_ << " "
+    << ((filename_ == "")?std::string("empty"):filename_) << " "
+    << ((scalingMode_ == "")?std::string("empty"):scalingMode_) << " "
+    << ((recentFile_ == "")?std::string("empty"):recentFile_) << std::endl;
+  f << "outputs [";
+  std::map<std::string, Output *> outputs = region_->getOutputs();
+  for (auto iter : outputs) {
+    const Array &outputBuffer = iter.second->getData();
+    if (outputBuffer.getCount() != 0) {
+      f << iter.first << " ";
+      outputBuffer.save(f);
+    }
+  }
+  f << "] "; // end of all output buffers
+  
+  f << "[" << std::endl;
+  vectorFile_.save(f);
+  f << "]" << std::endl;
+  f.flush();
+}
+
+void VectorFileSensor::deserialize(BundleIO &bundle) {
+  std::istream& f = bundle.getInputStream();
+  std::string tag;
+  f >> repeatCount_ >> activeOutputCount_ >> curVector_ >> iterations_ >>
+      hasCategoryOut_ >> hasResetOut_;
+  f >>  filename_ >> scalingMode_ >> recentFile_;
+  if (filename_ == "empty") filename_ = "";
+  if (scalingMode_ == "empty") scalingMode_ = "";
+  if (recentFile_ == "empty") recentFile_ = "";
+  f >> tag;
+  NTA_CHECK(tag == "outputs");
+  f.ignore(1);
+  NTA_CHECK(f.get() == '['); // start of outputs
+  while (true) {
+    f >> tag;
+    f.ignore(1);
+    if (tag == "]")
+      break;
+    Array& a = getOutput(tag)->getData();
+    a.load(f);
+  }
+  f >> tag;
+  NTA_CHECK(tag == "[");
+  f.ignore(1);
+  vectorFile_.load(f);
+  f >> tag;
+  NTA_CHECK(tag == "]") << "Expected the end of vectorFile.load";
+  f.ignore(1);
+}
+
+
+bool VectorFileSensor::operator==(const RegionImpl &o) const {
+  if (o.getType() != "VectorFileSensor") return false;
+  VectorFileSensor& other = (VectorFileSensor&)o;
+  if (repeatCount_ != other.repeatCount_) return false;
+  if (activeOutputCount_ != other.activeOutputCount_) return false;
+  if (curVector_ != other.curVector_) return false;
+  if (iterations_ != other.iterations_) return false;
+  if (hasCategoryOut_ != other.hasCategoryOut_) return false;
+  if (hasResetOut_ != other.hasResetOut_) return false;
+  if (filename_ != other.filename_) return false;
+  if (scalingMode_ != other.scalingMode_) return false;
+  if (recentFile_ != other.recentFile_) return false;
+
+  return true;
 }
 
 } // end namespace nupic

--- a/src/nupic/types/Sdr.hpp
+++ b/src/nupic/types/Sdr.hpp
@@ -126,8 +126,8 @@ using SDR_callback_t   = std::function<void()>;
 class SparseDistributedRepresentation : public Serializable
 {
 private:
-    std::vector<UInt> dimensions_;
-    UInt              size_;
+    mutable std::vector<UInt> dimensions_;
+    UInt                      size_;
 
 protected:
     /**
@@ -214,9 +214,9 @@ public:
      * @param dimensions A list of dimension sizes, defining the shape of the
      * SDR.  The product of the dimensions must be greater than zero.
      */
-    SparseDistributedRepresentation( const std::vector<UInt> dimensions );
+    SparseDistributedRepresentation( const std::vector<UInt> &dimensions );
 
-    void initialize( const std::vector<UInt> dimensions );
+    void initialize( const std::vector<UInt> &dimensions );
 
     /**
      * Initialize this SDR as a deep copy of the given SDR.  This SDR and the
@@ -238,6 +238,11 @@ public:
      * @attribute size The total number of boolean values in the SDR.
      */
     const UInt &size = size_;
+
+    /**
+     * Change the dimensions of the SDR.  The total size must not change.
+     */
+    void reshape(const std::vector<UInt> &dimensions) const;
 
     /**
      * Set all of the values in the SDR to false.  This method overwrites the
@@ -628,86 +633,6 @@ public:
 };
 
 typedef SparseDistributedRepresentation SDR;
-
-/**
- * Reshape class
- *
- * ### Description
- * Reshape presents a view onto an SDR with different dimensions.
- *      + Reshape is a subclass of SDR and be safely typecast to an SDR.
- *      + The resulting SDR has the same value as the source SDR, at all times
- *        and automatically.
- *      + The resulting SDR is read only.
- *
- * SDR and Reshape classes tell each other when they are created and
- * destroyed.  Reshape can be created and destroyed as needed.  Reshape
- * will throw an exception if it is used after its source SDR has been
- * destroyed.
- *
- * Example Usage:
- *      // Convert SDR dimensions from (4 x 4) to (8 x 2)
- *      SDR     A(    { 4, 4 })
- *      Reshape B( A, { 8, 2 })
- *      A.setCoordinates( {1, 1, 2}, {0, 1, 2}} )
- *      B.getCoordinates()  ->  {{2, 2, 5}, {0, 1, 0}}
- *
- * Reshape partially supports the Serializable interface.  Reshape can
- * be saved but can not be loaded.
- *
- * Note: Reshape used to be called SDR_Proxy. See PR #298
- */
-class Reshape : public SDR
-{
-public:
-    /**
-     * Reshape an SDR.
-     *
-     * @param sdr Source SDR to make a view of.
-     *
-     * @param dimensions A list of dimension sizes, defining the shape of the
-     * SDR.  Optional, if not given then this SDR will have the same
-     * dimensions as the given SDR.
-     */
-    Reshape(const SDR &sdr, const std::vector<UInt> &dimensions);
-
-    Reshape(const SDR &sdr)
-        : Reshape(sdr, sdr.dimensions) {}
-
-    SDR_dense_t& getDense() const override;
-
-    SDR_sparse_t& getSparse() const override;
-
-    SDR_coordinate_t& getCoordinates() const override;
-
-    void save(std::ostream &outStream) const override;
-
-    ~Reshape() override
-        { deconstruct(); }
-
-protected:
-    /**
-     * This SDR shall always have the same value as the parent SDR.
-     */
-    const SDR *parent;
-    UInt callback_handle;
-    UInt destroyCallback_handle;
-
-    void deconstruct() override;
-
-private:
-    const std::string _error_message = "This SDR is read only.";
-
-    void setDenseInplace() const override
-        { NTA_THROW << _error_message; }
-    void setSparseInplace() const override
-        { NTA_THROW << _error_message; }
-    void setCoordinatesInplace() const override
-        { NTA_THROW << _error_message; }
-    void setSDR( const SparseDistributedRepresentation &value ) override
-        { NTA_THROW << _error_message; }
-    void load(std::istream &inStream) override
-        { NTA_THROW << _error_message; }
-};
 
 } // end namespace sdr
 } // end namespace nupic

--- a/src/nupic/types/Types.hpp
+++ b/src/nupic/types/Types.hpp
@@ -123,8 +123,10 @@ typedef std::size_t Size;
  */
 #ifdef NTA_DOUBLE_PRECISION
   typedef Real64 Real;
+  const int FLOAT_PRECISION = 8; // bytes
 #else
   typedef Real32 Real;
+  const int FLOAT_PRECISION = 4; // bytes
 #endif
 
 /**
@@ -134,8 +136,10 @@ typedef std::size_t Size;
  */
 #ifdef NTA_BIG_INTEGER
   typedef Int64 Int;
+  const int INT_PRECISION = 8; // bytes
 #else
   typedef Int32 Int;
+  const int INT_PRECISION = 4; // bytes
 #endif
 
 /**

--- a/src/nupic/types/Types.hpp
+++ b/src/nupic/types/Types.hpp
@@ -123,10 +123,8 @@ typedef std::size_t Size;
  */
 #ifdef NTA_DOUBLE_PRECISION
   typedef Real64 Real;
-  const int FLOAT_PRECISION = 8; // bytes
 #else
   typedef Real32 Real;
-  const int FLOAT_PRECISION = 4; // bytes
 #endif
 
 /**
@@ -136,10 +134,8 @@ typedef std::size_t Size;
  */
 #ifdef NTA_BIG_INTEGER
   typedef Int64 Int;
-  const int INT_PRECISION = 8; // bytes
 #else
   typedef Int32 Int;
-  const int INT_PRECISION = 4; // bytes
 #endif
 
 /**

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -91,6 +91,7 @@ set(regions_tests
 	   unit/regions/RegionTestUtilities.hpp
 	   unit/regions/SPRegionTest.cpp
            unit/regions/TMRegionTest.cpp
+           unit/regions/VectorFileTest.cpp
 	   )
 
 	   

--- a/src/test/unit/engine/HelloRegionTest.cpp
+++ b/src/test/unit/engine/HelloRegionTest.cpp
@@ -100,11 +100,11 @@ TEST(HelloRegionTest, demo) {
   Network net2;
   {
     std::stringstream ss;
-    net.save(ss);
+    net.saveToStream_ar(ss, SerializableFormat::JSON);
 	  if(verbose) std::cout << "Loading from stream. \n";
     if(verbose) std::cout << ss.str() << std::endl;
     ss.seekg(0);
-    net2.load(ss);
+    net2.loadFromStream_ar(ss, SerializableFormat::JSON);
   }
 
   // Note: this compares the structure (regions, links, etc) not data content or state.

--- a/src/test/unit/engine/LinkTest.cpp
+++ b/src/test/unit/engine/LinkTest.cpp
@@ -500,6 +500,15 @@ public:
   // De-serialize state. Must be called from deserializing constructor
   void deserialize(BundleIO &bundle) override {}
 
+  
+  bool operator==(const RegionImpl &other) const override { 
+    NTA_THROW << "equals not implemented for this test case";
+  }
+  inline bool operator!=(const TestRegionBase &other) const {
+    return !operator==(other);
+  }
+
+
 
   // Execute a command
   std::string executeCommand(const std::vector<std::string> &args,

--- a/src/test/unit/engine/NetworkTest.cpp
+++ b/src/test/unit/engine/NetworkTest.cpp
@@ -527,11 +527,7 @@ TEST(NetworkTest, testEqualsOperator) {
   auto l1 = n1.addRegion("level1", "TestNode", "");
   ASSERT_TRUE(n1 != n2);
   auto l2 = n2.addRegion("level1", "TestNode", "");
-  ASSERT_TRUE(n1 == n2);   // NOTE: This only checks if the structure is the same
-                           // It does not know anything about internal state
-                           // or data content.
-                           // But maybe this is good enough; I don't know.
-
+  ASSERT_TRUE(n1 == n2);   
   l1->setDimensions(d);
   ASSERT_TRUE(n1 != n2);
   l2->setDimensions(d);

--- a/src/test/unit/regions/RegionTestUtilities.cpp
+++ b/src/test/unit/regions/RegionTestUtilities.cpp
@@ -78,7 +78,7 @@ void checkGetSetAgainstSpec(std::shared_ptr<Region> region1,
           if (negativeCheck) {
 				    negativeCheck = false;
 				    VERBOSE << "negative check..." << std::endl;
-				    EXPECT_THROW(region1->getParameterInt32("numberOfCols"), nupic::Exception); 
+				    EXPECT_THROW(region1->getParameterInt32("bad_parameter"), nupic::Exception); 
 			    }
           VERBOSE << "Parameter \"" << name << "\" type: " << BasicType::getName(p.second.dataType) << std::endl;
 

--- a/src/test/unit/regions/VectorFileTest.cpp
+++ b/src/test/unit/regions/VectorFileTest.cpp
@@ -1,0 +1,327 @@
+/* ---------------------------------------------------------------------
+ * Numenta Platform for Intelligent Computing (NuPIC)
+ * Copyright (C) 2018, Numenta, Inc.  Unless you have an agreement
+ * with Numenta, Inc., for a separate license for this software code, the
+ * following terms and conditions apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * http://numenta.org/licenses/
+ 
+ * Author: David Keeney, April, 2019
+ * ---------------------------------------------------------------------
+ */
+ 
+/*---------------------------------------------------------------------
+  * This is a test of the VectorFileEffector and VectorFileSensor modules.  
+  *
+  * For those not familiar with GTest:
+  *     ASSERT_TRUE(value)   -- Fatal assertion that the value is true.  Test terminates if false.
+  *     ASSERT_FALSE(value)   -- Fatal assertion that the value is false. Test terminates if true.
+  *     ASSERT_STREQ(str1, str2)   -- Fatal assertion that the strings are equal. Test terminates if false.
+  *
+  *     EXPECT_TRUE(value)   -- Nonfatal assertion that the value is true.  Test fails but continues if false.
+  *     EXPECT_FALSE(value)   -- Nonfatal assertion that the value is false. Test fails but continues if true.
+  *     EXPECT_STREQ(str1, str2)   -- Nonfatal assertion that the strings are equal. Test fails but continues if false.
+  *
+  *     EXPECT_THROW(statement, exception_type) -- nonfatal exception, cought and continues.
+  *---------------------------------------------------------------------
+  */
+
+
+#include <nupic/engine/NuPIC.hpp>
+#include <nupic/engine/Network.hpp>
+#include <nupic/engine/Region.hpp>
+#include <nupic/engine/Spec.hpp>
+#include <nupic/engine/Input.hpp>
+#include <nupic/engine/Output.hpp>
+#include <nupic/engine/Link.hpp>
+#include <nupic/engine/RegisteredRegionImpl.hpp>
+#include <nupic/engine/RegisteredRegionImplCpp.hpp>
+#include <nupic/ntypes/Array.hpp>
+#include <nupic/types/Exception.hpp>
+#include <nupic/os/Env.hpp>
+#include <nupic/os/Path.hpp>
+#include <nupic/os/Timer.hpp>
+#include <nupic/os/Directory.hpp>
+#include <nupic/engine/YAMLUtils.hpp>
+#include <nupic/regions/SPRegion.hpp>
+#include <nupic/utils/LogItem.hpp>
+
+
+#include <string>
+#include <vector>
+#include <cmath> // fabs/abs
+#include <cstdlib> // exit
+#include <iostream>
+#include <stdexcept>
+#include <fstream>
+#include <streambuf>
+#include <iterator>
+#include <algorithm>
+
+
+
+#include "yaml-cpp/yaml.h"
+#include "gtest/gtest.h"
+#include "RegionTestUtilities.hpp"
+
+#define VERBOSE if(verbose)std::cerr << "[          ] "
+static bool verbose = false;  // turn this on to print extra stuff for debugging the test.
+
+// The following string should contain a valid expected Spec - manually verified. 
+#define EXPECTED_EFFECTOR_SPEC_COUNT  1  // The number of parameters expected in the VectorFileEffector Spec
+#define EXPECTED_SENSOR_SPEC_COUNT  11    // The number of parameters expected in the VectorFileSensor Spec
+
+using namespace nupic;
+namespace testing 
+{
+
+  //  forward declarations;  Find function body below.
+  static bool compareFiles(const std::string& p1, const std::string& p2); 
+	static void createTestData(size_t dataRows, 
+                             size_t dataWidth,
+                             const std::string& test_input_file,
+                             const std::string& test_output_file);
+
+
+  // Verify that all parameters are working.
+  // Assumes that the default value in the Spec is the same as the default 
+  // when creating a region with default constructor.
+  TEST(VectorFileTest, testSpecAndParametersEffector)
+  {
+    Network net;
+
+    // create an Effector region with default parameters
+    std::shared_ptr<Region> region1 = net.addRegion("region1", "VectorFileEffector", "");  // use default configuration
+
+		std::set<std::string> excluded;
+    checkGetSetAgainstSpec(region1, EXPECTED_EFFECTOR_SPEC_COUNT, excluded, verbose);
+    checkInputOutputsAgainstSpec(region1, verbose);
+
+  }
+  TEST(VectorFileTest, testSpecAndParametersSensor)
+  {
+    Network net;
+
+    // create an Sensor region with default parameters
+    std::shared_ptr<Region> region1 = net.addRegion("region1", "VectorFileSensor", "");  // use default configuration
+
+    std::set<std::string> excluded = {"scalingMode", "position"};
+    checkGetSetAgainstSpec(region1, EXPECTED_SENSOR_SPEC_COUNT, excluded, verbose);
+    checkInputOutputsAgainstSpec(region1, verbose);
+
+  }
+
+  
+	TEST(VectorFileTest, Seeking)
+	{
+    std::string test_input_file = "TestOutputDir/TestInput.csv";
+    std::string test_output_file = "TestOutputDir/TestOutput.csv";
+    size_t dataWidth = 10;
+    size_t dataRows = 10;
+		createTestData(dataRows, dataWidth, test_input_file, test_output_file);
+
+    Network net;
+    std::string params = "{dim: [" + std::to_string(dataWidth) + "]}";
+    std::shared_ptr<Region> region1 = net.addRegion("region1", "VectorFileSensor", params);
+    EXPECT_EQ(region1->getParameterInt32("position"), -1);
+
+    region1->executeCommand({ "loadFile", test_input_file });
+    EXPECT_EQ(region1->getParameterInt32("position"), 9);
+    net.run(1);
+
+    EXPECT_EQ(region1->getParameterInt32("position"), 0);
+    Array a = region1->getOutputData("dataOut");
+    VERBOSE << "1st vector=" << a << std::endl;
+    Array expected1(std::vector<Real32>({ 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }));
+    EXPECT_TRUE(a == expected1);
+
+
+    region1->setParameterInt32("position", 5);
+    net.run(1);
+    EXPECT_EQ(region1->getParameterInt32("position"), 5);
+    a = region1->getOutputData("dataOut");
+    VERBOSE << "5th vector=" << a << std::endl;
+    Array expected5(std::vector<Real32>({ 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f }));
+    EXPECT_TRUE(a == expected5);
+
+    // cleanup
+    Directory::removeTree("TestOutputDir", true);
+  }
+
+	TEST(VectorFileTest, testLinking)
+	{
+    // This is a minimal end-to-end test containing an Effector and a Sensor region
+    // this test will hook up the VectorFileSensor to a VectorFileEffector to capture the results.
+    //
+    std::string test_input_file = "TestOutputDir/TestInput.csv";
+    std::string test_output_file = "TestOutputDir/TestOutput.csv";
+    size_t dataWidth = 10;
+    size_t dataRows = 10;
+		createTestData(dataRows, dataWidth, test_input_file, test_output_file);
+
+
+    VERBOSE << "Setup Network; add 2 regions and 1 link." << std::endl;
+	  Network net;
+
+    // Explicit parameters:  (Yaml format...but since YAML is a superset of JSON, 
+    // you can use JSON format as well)
+
+    std::shared_ptr<Region> region1 = net.addRegion("region1", "VectorFileSensor", "{activeOutputCount: 10}");
+    std::shared_ptr<Region> region3 = net.addRegion("region3", "VectorFileEffector", "{outputFile: '"+ test_output_file + "'}");
+
+
+    net.link("region1", "region3", "", "", "dataOut", "dataIn");
+
+    VERBOSE << "Load Data." << std::endl;
+    region1->executeCommand({ "loadFile", test_input_file });
+
+
+    VERBOSE << "Initialize." << std::endl;
+    net.initialize();
+
+    VERBOSE << "Execute once." << std::endl;
+    //LogItem::setLogLevel(LogLevel_Verbose);
+    net.run(1);
+    //LogItem::setLogLevel(LogLevel_None);
+
+	  VERBOSE << "Checking data after first iteration..." << std::endl;
+    EXPECT_EQ(region1->getParameterInt32("position"), 0);
+    VERBOSE << "  VectorFileSensor Output" << std::endl;
+    Array r1OutputArray = region1->getOutputData("dataOut");
+    EXPECT_EQ(r1OutputArray.getCount(), dataWidth);
+    EXPECT_TRUE(r1OutputArray.getType() == NTA_BasicType_Real32)
+            << "actual type is " << BasicType::getName(r1OutputArray.getType());
+
+    Array r3InputArray = region3->getInputData("dataIn");
+    ASSERT_TRUE(r3InputArray.getType() == NTA_BasicType_Real32)
+      << "actual type is " << BasicType::getName(r3InputArray.getType());
+    ASSERT_TRUE(r3InputArray.getCount() == dataWidth);
+
+		VERBOSE << "  VectorFileSensor  output: " << r1OutputArray << std::endl;
+    VERBOSE << "  VectorFileEffector input: " << r3InputArray << std::endl;
+		
+
+	  // execute network several more times and check that it has output.
+    VERBOSE << "Execute 9 more times." << std::endl;
+    net.run(9);
+    EXPECT_EQ(region1->getParameterInt32("position"), 9);
+
+
+    r1OutputArray = region1->getOutputData("dataOut");
+    r3InputArray = region3->getInputData("dataIn");
+		VERBOSE << "  VectorFileSensor  output: " << r1OutputArray << std::endl;
+    VERBOSE << "  VectorFileEffector input: " << r3InputArray << std::endl;
+    EXPECT_TRUE(r3InputArray == r1OutputArray);
+
+    // cleanup
+    region3->executeCommand({ "closeFile" });
+		
+		// Compare files
+    ASSERT_TRUE(compareFiles(test_input_file, test_output_file)) << "Files should be the same.";
+
+    VERBOSE << "Execute 1 more time to verify the wrap." << std::endl;
+    net.run(1);
+    // The current position should be 0 because it wraps at 10.
+    EXPECT_EQ(region1->getParameterInt32("position"), 0);
+}
+
+
+TEST(VectorFileTest, testSerialization)
+{
+    std::string test_input_file = "TestOutputDir/TestInput.csv";
+    std::string test_output_file = "TestOutputDir/TestOutput.csv";
+    size_t dataWidth = 10;
+    size_t dataRows = 10;
+		createTestData(dataRows, dataWidth, test_input_file, test_output_file);
+		
+	  // use default parameters the first time
+	  Network net1;
+	  Network net3;
+
+	  VERBOSE << "Setup first network and save it" << std::endl;
+    std::shared_ptr<Region> n1region1 = net1.addRegion("region1", "VectorFileSensor", "{activeOutputCount: "+std::to_string(dataWidth) +"}");
+    std::shared_ptr<Region> n1region3 = net1.addRegion("region3", "VectorFileEffector", "{outputFile: '"+ test_output_file + "'}");
+    net1.link("region1", "region3", "", "", "dataOut", "dataIn");
+
+    VERBOSE << "Load Data." << std::endl;
+    n1region1->executeCommand({ "loadFile", test_input_file });
+    net1.initialize();
+
+		net1.run(1);
+
+    Directory::removeTree("TestOutputDir", true);
+	  net1.saveToFile_ar("TestOutputDir/VectorFileTest.stream");
+
+	  VERBOSE << "Restore into a second network and compare." << std::endl;
+    net3.loadFromFile_ar("TestOutputDir/VectorFileTest.stream");
+	  std::shared_ptr<Region> n3region1 = net3.getRegion("region1");
+	  std::shared_ptr<Region> n3region3 = net3.getRegion("region3");
+
+    EXPECT_TRUE(*n1region1.get() == *n3region1.get());
+    EXPECT_TRUE(*n1region3.get() == *n3region3.get());
+
+    // cleanup
+    Directory::removeTree("TestOutputDir", true);
+
+	}
+	
+	//////////////////////////////////////////////////////////////////////////////////
+
+	static bool compareFiles(const std::string& p1, const std::string& p2) {
+	  std::ifstream f1(p1, std::ifstream::binary|std::ifstream::ate);
+	  std::ifstream f2(p2, std::ifstream::binary|std::ifstream::ate);
+
+	  if (f1.fail() || f2.fail()) {
+	    return false; //file problem
+	  }
+
+	  if (f1.tellg() != f2.tellg()) {
+	    return false; //size mismatch
+	  }
+
+	  //seek back to beginning and use std::equal to compare contents
+	  f1.seekg(0, std::ifstream::beg);
+	  f2.seekg(0, std::ifstream::beg);
+	  return std::equal(std::istreambuf_iterator<char>(f1.rdbuf()),
+	                    std::istreambuf_iterator<char>(),
+	                    std::istreambuf_iterator<char>(f2.rdbuf()));
+	}
+	
+	static void createTestData(size_t dataRows, size_t dataWidth,
+                             const std::string& test_input_file,
+                             const std::string& test_output_file) {
+	    // make a place to put test data.
+    if (!Directory::exists("TestOutputDir")) Directory::create("TestOutputDir", false, true); 
+    if (Path::exists(test_input_file)) Path::remove(test_input_file);
+    if (Path::exists(test_output_file)) Path::remove(test_output_file);
+
+    // Create a csv file to use as input.
+    // The SDR data we will feed it will be a matrix with 1's on the diagonal
+    // and we will feed it one row at a time, for 'dataRows' rows.
+    std::ofstream  f(test_input_file.c_str());
+    for (size_t i = 0; i < dataRows; i++) {
+      for (size_t j = 0; j < dataWidth; j++) {
+        if (j > 0) f << ",";
+        if ((j % dataRows) == i) f << "1";
+        else f << "0";
+      }
+      f << std::endl;
+    }
+    f.close();
+  }
+
+
+} // namespace
+

--- a/src/test/unit/types/SdrTest.cpp
+++ b/src/test/unit/types/SdrTest.cpp
@@ -137,6 +137,19 @@ TEST(SdrTest, TestSDR_Examples) {
     ASSERT_EQ( before, after );
 }
 
+TEST(SdrTest, TestReshape) {
+    SDR A({3,4,5});
+    A.randomize( 5. / A.size );
+    const auto data = A.getSparse();
+    // Make the SDR have only the coordinate dataformat, because that could get
+    // corrupted by the reshape.
+    A.setCoordinates( A.getCoordinates() );
+    A.reshape({5,4*3});
+    ASSERT_EQ( A.getSparse(), data );
+    ASSERT_EQ( A.dimensions, vector<UInt>({5,12}) );
+    ASSERT_ANY_THROW( A.reshape({ 2 }) );
+}
+
 TEST(SdrTest, TestSetDenseVec) {
     SDR a({11, 10, 4});
     Byte *before = a.getDense().data();
@@ -759,8 +772,6 @@ TEST(SdrTest, TestCallbacks) {
     SDR_callback_t call2 = [&](){ count2++; };
     int count3 = 0;
     SDR_callback_t call3 = [&](){ count3++; };
-    int count4 = 0;
-    SDR_callback_t call4 = [&](){ count4++; };
 
     A.zero();   // No effect on callbacks
     A.zero();   // No effect on callbacks
@@ -769,9 +780,6 @@ TEST(SdrTest, TestCallbacks) {
     UInt handle1 = A.addCallback( call1 );
     UInt handle2 = A.addCallback( call2 );
     UInt handle3 = A.addCallback( call3 );
-    // Test reshape gets callbacks
-    Reshape C(A);
-    C.addCallback( call4 );
 
     // Remove call 2 and add it back in.
     A.removeCallback( handle2 );
@@ -819,180 +827,8 @@ TEST(SdrTest, TestCallbacks) {
     SDR B(A);
     ASSERT_ANY_THROW( B.removeCallback( handle1 ) );
     ASSERT_ANY_THROW( B.removeCallback( 0 ) );
-    // Check SDR Reshape got all of the callbacks and passed them along.
-    ASSERT_EQ( count4, 4 );
 }
 
-
-TEST(SdrReshapeTest, TestReshapeExamples) {
-    SDR     A(    { 4, 4 });
-    Reshape B( A, { 8, 2 });
-    A.setCoordinates(SDR_coordinate_t({{1, 1, 2}, {0, 1, 2}}));
-    auto coords = B.getCoordinates();
-    ASSERT_EQ(coords, SDR_coordinate_t({{2, 2, 5}, {0, 1, 0}}));
-}
-
-TEST(SdrReshapeTest, TestReshapeConstructor) {
-    SDR       A({ 11 });
-    Reshape   B( A );
-    ASSERT_EQ( A.dimensions, B.dimensions );
-    Reshape   C( A, { 11 });
-    SDR       D({ 5, 4, 3, 2, 1 });
-    Reshape   E( D, {1, 1, 1, 120, 1});
-    Reshape   F( D, { 20, 6 });
-    Reshape   X( (SDR&) F );
-
-    // Test that SDR Reshapes can be safely made and destroyed.
-    Reshape *G = new Reshape( A );
-    Reshape *H = new Reshape( A );
-    Reshape *I = new Reshape( A );
-    A.zero();
-    H->getDense();
-    delete H;
-    I->getDense();
-    A.zero();
-    Reshape *J = new Reshape( A );
-    J->getDense();
-    Reshape *K = new Reshape( A );
-    delete K;
-    Reshape *L = new Reshape( A );
-    L->getCoordinates();
-    delete L;
-    delete G;
-    I->getCoordinates();
-    delete I;
-    delete J;
-    A.getDense();
-
-    // Test invalid dimensions
-    ASSERT_ANY_THROW( new Reshape( A, {2, 5}) );
-    ASSERT_ANY_THROW( new Reshape( A, {11, 0}) );
-}
-
-TEST(SdrReshapeTest, TestReshapeDeconstructor) {
-    SDR     *A = new SDR({12});
-    Reshape *B = new Reshape( *A );
-    Reshape *C = new Reshape( *A, {3, 4} );
-    Reshape *D = new Reshape( *C, {4, 3} );
-    Reshape *E = new Reshape( *C, {2, 6} );
-    D->getDense();
-    E->getCoordinates();
-    // Test subtree deletion
-    delete C;
-    ASSERT_ANY_THROW( D->getDense() );
-    ASSERT_ANY_THROW( E->getCoordinates() );
-    ASSERT_ANY_THROW( new Reshape( *E ) );
-    delete D;
-    // Test rest of tree is OK.
-    B->getSparse();
-    A->zero();
-    B->getSparse();
-    // Test delete root.
-    delete A;
-    ASSERT_ANY_THROW( B->getDense() );
-    ASSERT_ANY_THROW( E->getCoordinates() );
-    // Cleanup remaining Reshapes.
-    delete B;
-    delete E;
-}
-
-TEST(SdrReshapeTest, TestReshapeThrows) {
-    SDR A({10});
-    Reshape B(A, {2, 5});
-    SDR *C = &B;
-
-    ASSERT_ANY_THROW( C->setDense( SDR_dense_t( 10, 1 ) ));
-    ASSERT_ANY_THROW( C->setCoordinates( SDR_coordinate_t({ {0}, {0} }) ));
-    ASSERT_ANY_THROW( C->setSparse( SDR_sparse_t({ 0, 1, 2 }) ));
-    SDR X({10});
-    ASSERT_ANY_THROW( C->setSDR( X ));
-    ASSERT_ANY_THROW( C->randomize(0.10f) );
-    ASSERT_ANY_THROW( C->addNoise(0.10f) );
-}
-
-TEST(SdrReshapeTest, TestReshapeGetters) {
-    SDR A({ 2, 3 });
-    Reshape B( A, { 3, 2 });
-    SDR *C = &B;
-    // Test getting dense
-    A.setDense( SDR_dense_t({ 0, 1, 0, 0, 1, 0 }) );
-    ASSERT_EQ( C->getDense(), SDR_dense_t({ 0, 1, 0, 0, 1, 0 }) );
-
-    // Test getting coordinates
-    A.setCoordinates( SDR_coordinate_t({ {0, 1}, {0, 1} }));
-    ASSERT_EQ( C->getCoordinates(), SDR_coordinate_t({ {0, 2}, {0, 0} }) );
-
-    // Test getting sparse
-    A.setSparse( SDR_sparse_t({ 2, 3 }));
-    ASSERT_EQ( C->getSparse(), SDR_sparse_t({ 2, 3 }) );
-
-    // Test getting coordinates, a second time.
-    A.setSparse( SDR_sparse_t({ 2, 3 }));
-    ASSERT_EQ( C->getCoordinates(), SDR_coordinate_t({ {1, 1}, {0, 1} }) );
-
-    // Test getting coordinates, when the parent SDR already has coordinates
-    // computed and the dimensions are the same.
-    A.zero();
-    Reshape D( A );
-    SDR *E = &D;
-    A.setCoordinates( SDR_coordinate_t({ {0, 1}, {0, 1} }));
-    ASSERT_EQ( E->getCoordinates(), SDR_coordinate_t({ {0, 1}, {0, 1} }) );
-}
-
-TEST(SdrReshapeTest, TestSaveLoad) {
-    const char *filename = "SdrReshapeSerialization.tmp";
-    ofstream outfile;
-    outfile.open(filename);
-
-    // Test zero value
-    SDR zero({ 3, 3 });
-    Reshape z( zero );
-    z.save( outfile );
-
-    // Test dense data
-    SDR dense({ 3, 3 });
-    Reshape d( dense );
-    dense.setDense(SDR_dense_t({ 0, 1, 0, 0, 1, 0, 0, 0, 1 }));
-    Serializable &ser = d;
-    ser.save( outfile );
-
-    // Test sparse data
-    SDR sparse({ 3, 3 });
-    Reshape f( sparse );
-    sparse.setSparse(SDR_sparse_t({ 1, 4, 8 }));
-    f.save( outfile );
-
-    // Test coordinate data
-    SDR coord({ 3, 3 });
-    Reshape x( coord );
-    coord.setCoordinates(SDR_coordinate_t({
-            { 0, 1, 2 },
-            { 1, 1, 2 }}));
-    x.save( outfile );
-
-    // Now load all of the data back into SDRs.
-    outfile.close();
-    ifstream infile( filename );
-
-    SDR zero_2;
-    zero_2.load( infile );
-    SDR dense_2;
-    dense_2.load( infile );
-    SDR sparse_2;
-    sparse_2.load( infile );
-    SDR coord_2;
-    coord_2.load( infile );
-
-    infile.close();
-    int ret = ::remove( filename );
-    EXPECT_TRUE(ret == 0) << "Failed to delete " << filename;
-
-    // Check that all of the data is OK
-    ASSERT_TRUE( zero    == zero_2 );
-    ASSERT_TRUE( dense   == dense_2 );
-    ASSERT_TRUE( sparse  == sparse_2 );
-    ASSERT_TRUE( coord   == coord_2 );
-}
 
 TEST(SdrTest, TestAssignmentOperator) 
 {

--- a/src/test/unit/utils/SdrMetricsTest.cpp
+++ b/src/test/unit/utils/SdrMetricsTest.cpp
@@ -18,7 +18,6 @@
 #include <gtest/gtest.h>
 #include <nupic/types/Sdr.hpp>
 #include <nupic/utils/SdrMetrics.hpp>
-/* Some of these tests also test SDR Reshape. */
 #include <vector>
 #include <random>
 
@@ -69,10 +68,9 @@ TEST(SdrMetricsTest, TestSparsityExample) {
  */
 TEST(SdrMetricsTest, TestSparsityShortTerm) {
     SDR A({1});
-    Reshape B( A );
     Real period = 10u;
     Real alpha  = 1.0f / period;
-    Sparsity S( B, (UInt)period );
+    Sparsity S( A, (UInt)period );
 
     A.setDense(SDR_dense_t{ 1 });
     ASSERT_FLOAT_EQ( S.sparsity, 1.0f );
@@ -140,8 +138,7 @@ TEST(SdrMetricsTest, TestSparsityLongTerm) {
     auto iterations = 1000u;
 
     SDR A({1000u});
-    Reshape B( A );
-    Sparsity S( B, period );
+    Sparsity S( A, period );
 
     vector<Real> test_means{ 0.01f,  0.05f,  0.20f, 0.50f, 0.50f, 0.75f, 0.99f };
     vector<Real> test_stdev{ 0.001f, 0.025f, 0.10f, 0.33f, 0.01f, 0.15f, 0.01f };
@@ -169,8 +166,7 @@ TEST(SdrMetricsTest, TestSparsityPrint) {
     // python unit tests.
     std::stringstream ss;
     SDR A({ 2000u });
-    Reshape B( A );
-    Sparsity S( B, 10u );
+    Sparsity S( A, 10u );
 
     A.randomize( 0.30f );
     A.randomize( 0.70f );
@@ -190,8 +186,7 @@ TEST(SdrMetricsTest, TestSparsityPrint) {
 TEST(SdrMetricsTest, TestAF_Construct) {
     // Test creating it.
     SDR *A = new SDR({ 5 });
-    Reshape *B = new Reshape( *A );
-    ActivationFrequency F( *B, 100 );
+    ActivationFrequency F( *A, 100 );
     ASSERT_ANY_THROW( ActivationFrequency F( *A, 0u ) ); // Period > 0!
     // Test nothing crashes with no data.
     F.min();
@@ -211,7 +206,6 @@ TEST(SdrMetricsTest, TestAF_Construct) {
     // Test use after freeing parent SDR.
     auto A_size = A->size;
     delete A;
-    delete B;
     F.min();
     F.mean();
     F.std();
@@ -225,8 +219,7 @@ TEST(SdrMetricsTest, TestAF_Construct) {
  */
 TEST(SdrMetricsTest, TestAF_Example) {
     SDR A({ 2u });
-    Reshape B( A );
-    ActivationFrequency F( B, 10u );
+    ActivationFrequency F( A, 10u );
 
     A.setDense(SDR_dense_t{ 0, 0 });
     ASSERT_EQ( F.activationFrequency, vector<Real>({ 0.0f, 0.0f }));
@@ -252,8 +245,7 @@ TEST(SdrMetricsTest, TestAF_LongTerm) {
     const auto period  =  1000u;
     const auto runtime = 10000u;
     SDR A({ 20u });
-    Reshape B( A );
-    ActivationFrequency F( B, period );
+    ActivationFrequency F( A, period );
 
 
     vector<Real> test_sparsity{ 0.0f, 0.05f, 1.0f, 0.25f, 0.5f };
@@ -279,8 +271,7 @@ TEST(SdrMetricsTest, TestAF_Entropy) {
     // Extact tests:
     // Test all zeros.
     SDR A({ size });
-    Reshape Px( A );
-    ActivationFrequency F( Px, period );
+    ActivationFrequency F( A, period );
     A.zero();
     EXPECT_FLOAT_EQ( F.entropy(), 0.0f );
 
@@ -382,8 +373,7 @@ TEST(SdrMetricsTest, TestOverlap_Construct) {
 
 TEST(SdrMetricsTest, TestOverlap_Example) {
     SDR A({ 10000u });
-    Reshape Px( A );
-    Overlap B( Px, 1000u );
+    Overlap B( A, 1000u );
     A.randomize( 0.05f );
     A.addNoise( 0.95f );         //   5% overlap
     A.addNoise( 0.55f );         //  45% overlap
@@ -397,8 +387,7 @@ TEST(SdrMetricsTest, TestOverlap_Example) {
 
 TEST(SdrMetricsTest, TestOverlap_ShortTerm) {
     SDR     A({ 1000u });
-    Reshape Px( A );
-    Overlap V( Px, 10u );
+    Overlap V( A, 10u );
 
     A.randomize( 0.20f ); // Initial value is taken after Overlap is created
 
@@ -431,8 +420,7 @@ TEST(SdrMetricsTest, TestOverlap_LongTerm) {
     const auto runtime = 1000u;
     const auto period  =  100u;
     SDR A({ 500u });
-    Reshape Px( A );
-    Overlap V( Px, period );
+    Overlap V( A, period );
     A.randomize( 0.45f );
 
     vector<Real> mean_ovlp{ 0.0f, 1.0f,
@@ -465,8 +453,7 @@ TEST(SdrMetricsTest, TestOverlap_Print) {
     // python unit tests.
     stringstream ss;
     SDR A({ 2000u });
-    Reshape Px( A );
-    Overlap V( Px, 100u );
+    Overlap V( A, 100u );
     A.randomize( 0.02f );
 
     vector<Real> overlaps{ 0.02f, 0.05f, 0.0f, 0.50f, 0.0f };
@@ -529,8 +516,7 @@ TEST(SdrMetricsTest, TestAllMetrics_Print) {
     // python unit tests.
   stringstream ss;
     SDR A({ 4097u });
-    Reshape Px( A );
-    Metrics M( Px, 100u );
+    Metrics M( A, 100u );
 
     vector<Real> sparsity{ 0.02f, 0.15f, 0.06f, 0.50f, 0.0f };
     vector<Real> overlaps{ 0.02f, 0.05f, 0.10f, 0.50f, 0.0f };


### PR DESCRIPTION
After this change I  successfully built the head branch using Anaconda on my Mac.

Note you may want to add to the build instructions that the following be run before the build on Mac:
export ARCHFLAGS="-arch x86_64"
export MACOSX_DEPLOYMENT_TARGET=10.14

In addition I "solved" the problem of the SpacialPooler.getPermanence() always returning zero values.
It turns out that PyBind11 will convert an array passed as an argument if the data types do not exactly match up with the C++ definitions. Then the C++ function only gets a converted copy of the numpy array, and any changes are lost after returning. This was what was happening to me.

If you pass the numpy array with the type matching the C++ argument then PyBind11 does not convert the data, and the C++ code can modify the data in-place. Once I discovered this, my ocr program gave exactly the same results in Python 3.77 as the original nupic Python 2.7 version.

I found this solution in this stack overflow query: https://stackoverflow.com/questions/54793539/pybind11-modify-numpy-array-from-c.

To test for this and to provide examples for others, I added a few unit tests to the Python Spacial Pooler bindings.