### PR TITLE
New methods SDR.union & SDR.killCells

### DIFF
--- a/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
+++ b/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
@@ -277,6 +277,18 @@ special, it is replaced with the system time.  The default seed is 0.)",
             py::arg("fractionNoise"),
             py::arg("seed") = 0u);
 
+        py_SDR.def("killCells", [](SDR *self, Real fraction, UInt seed) {
+            self->killCells( fraction, seed ); return self; },
+R"(Modify the SDR by setting a fraction of the bits to zero.
+
+Argument fraction must be between 0 and 1 (inclusive).  This fraction of the
+cells in the SDR will be set to zero, regardless of their current state.
+
+Argument seed is for a random number generator.  If not given, this uses the
+magic seed 0.  Use the same seed to consistently kill the same cells.)",
+            py::arg("fraction"),
+            py::arg("seed") = 0u);
+
         py_SDR.def("__str__", [](SDR &self){
             stringstream buf;
             buf << self;

--- a/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
+++ b/bindings/py/cpp_src/bindings/sdr/py_SDR.cpp
@@ -356,6 +356,24 @@ Example Usage:
         py_SDR.def("intersection", [](SDR *self, vector<const SDR*> inputs)
             { self->intersection(inputs); return self; });
 
+        py_SDR.def("union", [](SDR *self, SDR& inp1, SDR& inp2)
+            { self->set_union({ &inp1, &inp2}); return self; },
+R"(This method calculates the set union of the active bits in each input SDR.
+
+The output is stored in this SDR.  This method discards the SDRs current value!
+
+Example Usage:
+    A = SDR( 10 )
+    B = SDR( 10 )
+    U = SDR( 10 )
+    A.sparse = [0, 1, 2, 3]
+    B.sparse =       [2, 3, 4, 5]
+    U.union( A, B )
+    U.sparse -> [0, 1, 2, 3, 4, 5]
+)");
+        py_SDR.def("union", [](SDR *self, vector<const SDR*> inputs)
+            { self->set_union(inputs); return self; });
+
         py_SDR.def("concatenate", [](SDR *self, const SDR& inp1, const SDR& inp2, UInt axis)
             { self->concatenate(inp1, inp2, axis); return self; },
 R"(Concatenates SDRs and stores the result in this SDR.

--- a/bindings/py/tests/sdr/SDR_test.py
+++ b/bindings/py/tests/sdr/SDR_test.py
@@ -450,6 +450,61 @@ class IntersectionTest(unittest.TestCase):
             assert( X.getSparsity() <= (4./3.) * mean_sparsity )
 
 
+class UnionTest(unittest.TestCase):
+    def testExampleUsage(self):
+        A = SDR( 10 )
+        B = SDR( 10 )
+        U = SDR( A.dimensions )
+        A.sparse = [0, 1, 2, 3]
+        B.sparse =       [2, 3, 4, 5]
+        U.union( A, B )
+        assert(set(U.sparse) == set([0, 1, 2, 3, 4, 5]))
+
+    def testInPlace(self):
+        A = SDR( 1000 )
+        B = SDR( 1000 )
+        A.randomize( .50 )
+        B.randomize( .50 )
+        A.union( A, B )
+        assert( A.getSparsity() >= .75 - .05 and A.getSparsity() <= .75 + .05 )
+        A.union( B.randomize( .50 ), A.randomize( .50 ) )
+        assert( A.getSparsity() >= .75 - .05 and A.getSparsity() <= .75 + .05 )
+
+    def testReturn(self):
+        A = SDR( 10 ).randomize( .5 )
+        B = SDR( 10 ).randomize( .5 )
+        X = SDR( A.dimensions )
+        Y = X.union( A, B )
+        assert( X is Y )
+
+    def testSparsity(self):
+        test_cases = [
+            ( 0.5,  0.5 ),
+            ( 0.1,  0.9 ),
+            ( 0.25, 0.3 ),
+            ( 0.5,  0.5,  0.5 ),
+            ( 0.95, 0.95, 0.95 ),
+            ( 0.10, 0.10, 0.60 ),
+            ( 0.0,  1.0,  1.0 ),
+            ( 0.5,  0.5,  0.5, 0.5),
+            ( 0.11, 0.20, 0.05, 0.04, 0.03, 0.01, 0.01, 0.02, 0.02, 0.02),
+        ]
+        size = 10000
+        seed = 99
+        X    = SDR( size )
+        for sparsities in test_cases:
+            sdrs = []
+            for S in sparsities:
+                inp = SDR( size )
+                inp.randomize( S, seed)
+                seed += 1
+                sdrs.append( inp )
+            X.union( sdrs )
+            mean_sparsity = np.product(list( 1 - s for s in sparsities ))
+            assert( X.getSparsity() >= (2./3.) * (1 - mean_sparsity) )
+            assert( X.getSparsity() <= (4./3.) * (1 - mean_sparsity) )
+
+
 class ConcatenationTest(unittest.TestCase):
     def testExampleUsage(self):
         A = SDR( 10 )

--- a/bindings/py/tests/sdr/SDR_test.py
+++ b/bindings/py/tests/sdr/SDR_test.py
@@ -336,6 +336,36 @@ class SdrTest(unittest.TestCase):
         C = A.addNoise( .5 )
         assert( C is A )
 
+    def testKillCells(self):
+        A = SDR(1000).randomize(1.00)
+        # Test killing zero/no cells.
+        A.killCells( .00 ) # Check no seed does not crash.
+        assert( A.getSparsity() == 1.00 )
+        # Test killing half of the cells, 3 times in a row.
+        A.killCells( .50, 123 ) # Check seed as positional argument
+        assert( A.getSparsity() == .5 )
+        A.killCells( .50, seed=456 )
+        assert( A.getSparsity() >= .25 - .05 and A.getSparsity() <= .25 + .05 )
+        A.killCells( .50, seed=789 )
+        assert( A.getSparsity() >= .125 - .05 and A.getSparsity() <= .125 + .05 )
+        # Test killing all cells.
+        A.killCells( 1.00, seed=101 )
+        assert( A.getSparsity() == 0 )
+        # Check that the same seed always kills the same cells.
+        B = SDR(1000).randomize(1.00)
+        B.killCells(.50, seed=444)
+        B.killCells(.50, seed=444) # Kill the same cells twice, so no further change of sparsity.
+        assert( B.getSparsity() == .50 )
+        # Check different seeds kill different cells.
+        D = SDR(1000).randomize(1.00)
+        D.killCells(.50, seed=5)
+        D.killCells(.50, seed=6)
+        assert( D.getSparsity() < .50 )
+        # Check return value
+        X = SDR(100).randomize(.5)
+        Y = X.killCells(.10)
+        assert( X is Y )
+
     def testStr(self):
         A = SDR((103,))
         B = SDR((100, 100, 1))

--- a/src/nupic/types/Sdr.cpp
+++ b/src/nupic/types/Sdr.cpp
@@ -368,6 +368,44 @@ namespace sdr {
         SDR::setDenseInplace();
     }
 
+
+    void SparseDistributedRepresentation::set_union(
+            const SDR &input1, const SDR &input2) {
+        set_union( { &input1, &input2 } );
+    }
+
+    void SparseDistributedRepresentation::set_union(vector<const SDR*> inputs) {
+        NTA_CHECK( inputs.size() >= 2u );
+        bool inplace = false;
+        for( size_t i = 0; i < inputs.size(); i++ ) {
+            NTA_CHECK( inputs[i] != nullptr );
+            NTA_CHECK( inputs[i]->dimensions == dimensions );
+            // Check for modifying this SDR inplace.
+            if( inputs[i] == this ) {
+                inplace = true;
+                inputs[i--] = inputs.back();
+                inputs.pop_back();
+            }
+        }
+        if( inplace ) {
+            getDense(); // Make sure that the dense data is valid.
+        }
+        if( not inplace ) {
+            // Copy one of the SDRs over to the output SDR.
+            const auto &denseIn = inputs.back()->getDense();
+            dense_.assign( denseIn.begin(), denseIn.end() );
+            inputs.pop_back();
+            // inplace = true; // Now it's an inplace operation.
+        }
+        for(const auto &sdr_ptr : inputs) {
+            const auto &data = sdr_ptr->getDense();
+            for(auto z = 0u; z < data.size(); ++z) {
+                dense_[z] = dense_[z] || data[z];
+            }
+        }
+        SDR::setDenseInplace();
+    }
+
     void SparseDistributedRepresentation::concatenate(const SDR &inp1, const SDR &inp2, UInt axis)
         { concatenate({&inp1, &inp2}, axis); }
 

--- a/src/nupic/types/Sdr.cpp
+++ b/src/nupic/types/Sdr.cpp
@@ -327,7 +327,7 @@ namespace sdr {
     }
 
 
-    void SparseDistributedRepresentation::killCells(Real fraction, UInt seed) {
+    void SparseDistributedRepresentation::killCells(const Real fraction, const UInt seed) {
         NTA_CHECK( fraction >= 0.0 );
         NTA_CHECK( fraction <= 1.0 );
         const UInt nkill = round( size * fraction );

--- a/src/nupic/types/Sdr.cpp
+++ b/src/nupic/types/Sdr.cpp
@@ -330,17 +330,14 @@ namespace sdr {
     void SparseDistributedRepresentation::killCells(Real fraction, UInt seed) {
         NTA_CHECK( fraction >= 0.0 );
         NTA_CHECK( fraction <= 1.0 );
-        int nkill = round( size * fraction );
+        const UInt nkill = round( size * fraction );
         Random rng(seed);
         auto &data = getDense();
-        for( int i = size; i > 0; --i ) {
-            // Random sample. The probability to kill a cell is equal to the
-            // number of cells left to be killed, divided by the number of cells
-            // left to be visited.
-            if( rng.getReal64() <= (Real64) nkill / i ) {
-                data[i-1] = 0;
-                nkill--;
-            }
+	std::vector<ElemSparse> indices(size);
+	std::iota(indices.begin(), indices.end(), 0); //fills with 0,..,size-1
+	const auto toKill = rng.sample(indices, nkill); // select nkill indices to be "killed", set to OFF/0
+        for(const auto dis: toKill) {
+          data[dis] = 0;
         }
         setDense( data );
     }

--- a/src/nupic/types/Sdr.cpp
+++ b/src/nupic/types/Sdr.cpp
@@ -330,6 +330,22 @@ namespace sdr {
     }
 
 
+    void SparseDistributedRepresentation::killCells(Real fraction, UInt seed) {
+        NTA_CHECK( fraction >= 0.0 );
+        NTA_CHECK( fraction <= 1.0 );
+        int nkill = round( size * fraction );
+        Random rng(seed);
+        auto &data = getDense();
+        for( int i = size - 1; i >= 0; --i ) {
+            if( rng.getReal64() <= (Real64) nkill / (i+1) ) {
+                data[i] = 0;
+                nkill--;
+            }
+        }
+        setDense( data );
+    }
+
+
     void SparseDistributedRepresentation::intersection(
             const SDR &input1,
             const SDR &input2) {

--- a/src/nupic/types/Sdr.cpp
+++ b/src/nupic/types/Sdr.cpp
@@ -333,9 +333,12 @@ namespace sdr {
         int nkill = round( size * fraction );
         Random rng(seed);
         auto &data = getDense();
-        for( int i = size - 1; i >= 0; --i ) {
-            if( rng.getReal64() <= (Real64) nkill / (i+1) ) {
-                data[i] = 0;
+        for( int i = size; i > 0; --i ) {
+            // Random sample. The probability to kill a cell is equal to the
+            // number of cells left to be killed, divided by the number of cells
+            // left to be visited.
+            if( rng.getReal64() <= (Real64) nkill / i ) {
+                data[i-1] = 0;
                 nkill--;
             }
         }

--- a/src/nupic/types/Sdr.hpp
+++ b/src/nupic/types/Sdr.hpp
@@ -478,7 +478,7 @@ public:
      * given, this uses the magic seed 0.  Use the same seed to consistently
      * kill the same cells.
      */
-    void killCells(Real fraction, UInt seed=0u);
+    void killCells(const Real fraction, const UInt seed=0u);
 
     /**
      * This method calculates the set intersection of the active bits in each

--- a/src/nupic/types/Sdr.hpp
+++ b/src/nupic/types/Sdr.hpp
@@ -490,6 +490,31 @@ public:
     void intersection(std::vector<const SparseDistributedRepresentation*> inputs);
 
     /**
+     * This method calculates the set union of the active bits in all input SDRs.
+     *
+     * @params This method has two overloads:
+     *          1) Accepts two SDRs, for convenience.
+     *          2) Accepts a list of SDRs, must contain at least two SDRs, can
+     *             contain as many SDRs as needed.
+     *
+     * @returns In both cases the output is stored in this SDR.  This method
+     * modifies this SDR and discards its current value!
+     *
+     * Example Usage:
+     *     SDR A({ 10 });
+     *     SDR B({ 10 });
+     *     SDR C({ 10 });
+     *     A.setSparse({0, 1, 2, 3});
+     *     B.setSparse(      {2, 3, 4, 5});
+     *     C.set_union(A, B);
+     *     C.getSparse() -> {0, 1, 2, 3, 4, 5}
+     */
+    void set_union(const SparseDistributedRepresentation &input1,
+                   const SparseDistributedRepresentation &input2);
+
+    void set_union(std::vector<const SparseDistributedRepresentation*> inputs);
+
+    /**
      * Concatenates SDRs and stores the result in this SDR.
      *
      * @params This method has two overloads:

--- a/src/nupic/types/Sdr.hpp
+++ b/src/nupic/types/Sdr.hpp
@@ -464,6 +464,18 @@ public:
     void addNoise(Real fractionNoise, Random &rng);
 
     /**
+     * Modify the SDR by setting a fraction of the bits to zero.
+     *
+     * @param fraction The fraction of bits to set to zero.  Must be between 0
+     * and 1 (inclusive).
+     *
+     * @param seed The seed for the random number generator to draw from.  If not
+     * given, this uses the magic seed 0.  Use the same seed to consistently
+     * kill the same cells.
+     */
+    void killCells(Real fraction, UInt seed=0u);
+
+    /**
      * This method calculates the set intersection of the active bits in each
      * input SDR.
      *

--- a/src/test/unit/types/SdrTest.cpp
+++ b/src/test/unit/types/SdrTest.cpp
@@ -617,6 +617,35 @@ TEST(SdrTest, TestIntersection) {
     ASSERT_EQ( X.getSum(), 0u );
 }
 
+TEST(SdrTest, TestUnionExampleUsage) {
+    // Setup 2 SDRs to hold the inputs.
+    SDR A({ 10 });
+    SDR B({ 10 });
+    SDR C({ 10 });
+    A.setSparse(SDR_sparse_t{0, 1, 2, 3});
+    B.setSparse(SDR_sparse_t      {2, 3, 4, 5});
+    // Calculate the logical union
+    C.set_union(A, B);
+    ASSERT_EQ(C.getSparse(), SDR_sparse_t({0, 1, 2, 3, 4, 5}));
+}
+
+TEST(SdrTest, TestUnion) {
+    SDR A({1000});
+    SDR B(A.dimensions);
+    SDR U(A.dimensions);
+    A.randomize(.5);
+    B.randomize(.5);
+
+    // Test basic functionality
+    U.set_union(A, B);
+    U.getDense();
+    ASSERT_GT( U.getSparsity(), 1 - .25 * 2. );
+    ASSERT_LT( U.getSparsity(), 1 - .25 / 2. );
+    A.zero();
+    U.set_union(A, B);
+    ASSERT_EQ( U.getSparsity(), .5 );
+}
+
 TEST(SdrTest, TestConcatenationExampleUsage) {
     SDR A({ 10 });
     SDR B({ 10 });


### PR DESCRIPTION
New method for set logic Union operator.
In C++ it's named "set_union" because `union` is a reserved keyword.

New method `killCells` which sets a random sample of cells to zero.