### PR TITLE
Python Temporal Memory Documentation.

### DIFF
--- a/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_TemporalMemory.cpp
@@ -1,8 +1,10 @@
 /* ---------------------------------------------------------------------
  * Numenta Platform for Intelligent Computing (NuPIC)
- * Copyright (C) 2018, Numenta, Inc.  Unless you have an agreement
- * with Numenta, Inc., for a separate license for this software code, the
- * following terms and conditions apply:
+ * Copyright (C) 2018, Numenta, Inc.
+ *               2018, chhenning
+ *
+ * Unless you have an agreement with Numenta, Inc., for a separate license for
+ * this software code, the following terms and conditions apply:
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero Public License version 3 as
@@ -17,17 +19,13 @@
  * along with this program.  If not, see http://www.gnu.org/licenses.
  *
  * http://numenta.org/licenses/
- *
- * Author: @chhenning, 2018
- * ---------------------------------------------------------------------
- */
+ * --------------------------------------------------------------------- */
 
 /** @file
-PyBind11 bindings for HTM class
-*/
+ * PyBind11 bindings for HTM class
+ */
 
-
-#include <bindings/suppress_register.hpp>  //include before pybind11.h
+#include <bindings/suppress_register.hpp>  // include before pybind11.h
 #include <pybind11/pybind11.h>
 #include <pybind11/iostream.h>
 #include <pybind11/numpy.h>
@@ -37,20 +35,23 @@ PyBind11 bindings for HTM class
 
 #include "bindings/engine/py_utils.hpp"
 
-
-namespace nupic_ext
-{
-
 namespace py = pybind11;
 using namespace nupic;
 using nupic::sdr::SDR;
 using namespace nupic::algorithms::connections; 
 
+namespace nupic_ext
+{
     void init_TemporalMemory(py::module& m)
     {
         typedef nupic::algorithms::temporal_memory::TemporalMemory HTM_t;
 
-        py::class_<HTM_t> py_HTM(m, "TemporalMemory");
+        py::class_<HTM_t> py_HTM(m, "TemporalMemory",
+R"(Temporal Memory implementation in C++.
+
+Example usage:
+    TODO
+)");
 
         py_HTM.def(py::init<>());
         py_HTM.def(py::init<std::vector<CellIdx>
@@ -67,7 +68,66 @@ using namespace nupic::algorithms::connections;
                 , SegmentIdx
                 , SynapseIdx
                 , bool
-                , UInt>()
+                , UInt>(),
+R"(Initialize the temporal memory (TM) using the given parameters.
+
+Argument columnDimensions
+    Dimensions of the mini-column space
+
+Argument cellsPerColumn
+   Number of cells per mini-column
+
+Argument activationThreshold
+    If the number of active connected synapses on a segment is at least
+    this threshold, the segment is actived.
+
+Argument initialPermanence
+    Initial permanence of a new synapse.
+
+Argument connectedPermanence
+    If the permanence value for a synapse is greater than this value, then it
+    is connected.
+
+Argument minThreshold
+    If the number of potential synapses active on a segment is at least
+    this threshold, it is said to be "matching" and is eligible for
+    learning.
+
+Argument maxNewSynapseCount
+    The maximum number of synapses added to a segment during learning.
+
+Argument permanenceIncrement
+    Amount by which permanences of synapses are incremented during learning.
+
+Argument permanenceDecrement
+    Amount by which permanences of synapses are decremented during learning.
+
+Argument predictedSegmentDecrement
+    Amount by which segments are punished for incorrect predictions.
+    A good value is just a bit larger than (the column-level sparsity *
+    permanenceIncrement). So, if column-level sparsity is 2% and
+    permanenceIncrement is 0.01, this parameter should be something like 4% *
+    0.01 = 0.0004
+
+Argument seed
+    Seed for the random number generator.
+
+Argument maxSegmentsPerCell
+    The maximum number of segments per cell.
+
+Argument maxSynapsesPerSegment
+    The maximum number of synapses per segment.
+
+Argument checkInputs
+    Whether to check that the activeColumns are sorted without
+    duplicates. Disable this for a small speed boost.
+
+Argument extra
+    Number of external predictive inputs.  These inputs are used in addition to
+    the cells which are part of this TemporalMemory.  The TemporalMemory
+    requires all external inputs be identified by an index in the
+    range [0, extra).
+)"
                 , py::arg("columnDimensions")
                 , py::arg("cellsPerColumn") = 32
                 , py::arg("activationThreshold") = 13
@@ -122,7 +182,9 @@ using namespace nupic::algorithms::connections;
         py_HTM.def("activateCells", [](HTM_t& self, const SDR& activeColumns, bool learn)
         {
             self.activateCells(activeColumns, learn);
-        }, "Calculate the active cells, using the current active columns and dendrite segments.Grow and reinforce synapses."
+        },
+R"(Calculate the active cells, using the current active columns and
+dendrite segments.  Grow and reinforce synapses.)"
             , py::arg("activeColumns"), py::arg("learn") = true);
 
         py_HTM.def("compute", [](HTM_t& self, const SDR &activeColumns, bool learn)
@@ -132,9 +194,37 @@ using namespace nupic::algorithms::connections;
 
         py_HTM.def("compute", [](HTM_t& self, const SDR &activeColumns, bool learn,
                                  const SDR &extraActive, const SDR &extraWinners)
-            { self.compute(activeColumns, learn, extraActive, extraWinners); });
+            { self.compute(activeColumns, learn, extraActive, extraWinners); },
+R"(Perform one time step of the Temporal Memory algorithm.
 
-        py_HTM.def("reset", &HTM_t::reset);
+This method calls activateDendrites, then calls activateCells. Using
+the TemporalMemory via its compute method ensures that you'll always
+be able to call getActiveCells at the end of the time step.
+
+Argument activeColumns
+    SDR of active mini-columns.
+
+Argument learn
+    Whether or not learning is enabled.
+
+Argument extraActive
+    (optional) SDR of active external predictive inputs.  
+    External inputs must be cell indexes in the range [0, extra). 
+    TM must be set up with the 'extra' constructor parameter for this use.
+
+Argument extraWinners
+    (optional) SDR of winning external predictive inputs.  When learning, only these
+    inputs are considered active.  
+    ExtraWinners must be a subset of extraActive.
+)",
+                py::arg("activeColumns"),
+                py::arg("learn") = true,
+                py::arg("extraActive"),
+                py::arg("extraWinners"));
+
+        py_HTM.def("reset", &HTM_t::reset,
+R"(Indicates the start of a new sequence.
+Resets sequence state of the TM.)");
 
         py_HTM.def("getActiveCells", [](const HTM_t& self)
         {
@@ -148,38 +238,86 @@ using namespace nupic::algorithms::connections;
         py_HTM.def("activateDendrites", [](HTM_t &self, bool learn) {
             SDR extra({ self.extra });
             self.activateDendrites(learn, extra, extra);
-        });
+        },
+            py::arg("learn"));
+
+        py_HTM.def("activateDendrites",
+            [](HTM_t &self, bool learn,const SDR &extraActive, const SDR &extraWinners)
+                { self.activateDendrites(learn, extraActive, extraWinners); },
+R"(Calculate dendrite segment activity, using the current active cells.  Call
+this method before calling getPredictiveCells, getActiveSegments, or
+getMatchingSegments.  In each time step, only the first call to this
+method has an effect, subsequent calls assume that the prior results are
+still valid.
+
+Argument learn
+    If true, segment activations will be recorded. This information is
+    used during segment cleanup.
+
+Argument extraActive
+    (optional) SDR of active external predictive inputs.
+
+Argument extraWinners
+    (optional) SDR of winning external predictive inputs.  When learning, only
+    these inputs are considered active.
+    ExtraWinners must be a subset of extraActive.
+
+See TM.compute() for details of the parameters.)",
+            py::arg("learn"),
+            py::arg("extraActive"),
+            py::arg("extraWinners"));
 
         py_HTM.def("getPredictiveCells", [](const HTM_t& self)
-            { return self.getPredictiveCells();});
+            { return self.getPredictiveCells();},
+R"()");
 
         py_HTM.def("getWinnerCells", [](const HTM_t& self)
         {
-            auto winnerCells = self.getWinnerCells();
-
-            return py::array_t<nupic::UInt32>(winnerCells.size(), winnerCells.data());
-        });
+            auto dims = self.getColumnDimensions();
+            dims.push_back( self.getCellsPerColumn() );
+            SDR *winnerCells = new SDR( dims );
+            self.getWinnerCells(*winnerCells);
+            return winnerCells;
+        },
+R"()");
 
         py_HTM.def("getActiveSegments", [](const HTM_t& self)
-            { return self.getActiveSegments(); });
+            { return self.getActiveSegments(); },
+R"()");
 
         py_HTM.def("getMatchingSegments", [](const HTM_t& self)
-            { return self.getMatchingSegments(); });
+            { return self.getMatchingSegments(); },
+R"()");
 
         py_HTM.def("cellsForColumn", [](HTM_t& self, UInt columnIdx)
         {
             auto cells = self.cellsForColumn(columnIdx);
 
             return py::array_t<nupic::UInt32>(cells.size(), cells.data());
-        });
+        },
+R"(Returns list of indices of cells that belong to a mini-column.
 
-        py_HTM.def("createSegment", &HTM_t::createSegment);
+Argument column is sparse index of a mini-column.)");
 
-        py_HTM.def("numberOfCells",   &HTM_t::numberOfCells);
+        py_HTM.def("createSegment", &HTM_t::createSegment,
+R"(Create a segment on the specified cell. This method calls
+createSegment on the underlying connections, and it does some extra
+bookkeeping. Unit tests should call this method, and not
+connections.createSegment().
 
-        py_HTM.def("numberOfColumns", &HTM_t::numberOfColumns);
+Argument cell
+    Index of Cell to add a segment to.
 
-        py_HTM.def_property_readonly("extra", [](const HTM_t &self) { return self.extra; } );
+Returns the created segment (index handle).)");
+
+        py_HTM.def("numberOfCells",   &HTM_t::numberOfCells,
+R"(Returns the number of cells in this TemporalMemory.)");
+
+        py_HTM.def("numberOfColumns", &HTM_t::numberOfColumns,
+R"(Returns the total number of mini-columns.)");
+
+        py_HTM.def_property_readonly("extra", [](const HTM_t &self) { return self.extra; },
+R"()");
 
         py_HTM.def_property_readonly("anomaly", [](const HTM_t &self) { return self.anomaly; },
           "Anomaly score updated with each TM::compute() call. "


### PR DESCRIPTION
I copied the documentation from the C++ code into the python bindings.
Very minor functional change in method `getWinnerCells`, it now returns an SDR instead of a vector.