### PR TITLE
Spatial Pooler Python Documentation

### DIFF
--- a/bindings/py/cpp_src/bindings/algorithms/py_SpatialPooler.cpp
+++ b/bindings/py/cpp_src/bindings/algorithms/py_SpatialPooler.cpp
@@ -67,7 +67,126 @@ using namespace nupic;
             , UInt
             , bool>()
             , py::call_guard<py::scoped_ostream_redirect,
-                             py::scoped_estream_redirect>()
+                             py::scoped_estream_redirect>(),
+R"(
+Argument inputDimensions A list of integers representing the
+        dimensions of the input vector. Format is [height, width,
+        depth, ...], where each value represents the size of the
+        dimension. For a topology of one dimensions with 100 inputs
+        use [100]. For a two dimensional topology of 10x5
+        use [10,5].
+
+Argument columnDimensions A list of integers representing the
+        dimensions of the columns in the region. Format is [height,
+        width, depth, ...], where each value represents the size of
+        the dimension. For a topology of one dimensions with 2000
+        columns use 2000, or [2000]. For a three dimensional
+        topology of 32x64x16 use [32, 64, 16].
+
+Argument potentialRadius This parameter determines the extent of the
+        input that each column can potentially be connected to. This
+        can be thought of as the input bits that are visible to each
+        column, or a 'receptive field' of the field of vision. A large
+        enough value will result in global coverage, meaning
+        that each column can potentially be connected to every input
+        bit. This parameter defines a square (or hyper square) area: a
+        column will have a max square potential pool with sides of
+        length (2 * potentialRadius + 1).
+
+Argument potentialPct The percent of the inputs, within a column's
+        potential radius, that a column can be connected to. If set to
+        1, the column will be connected to every input within its
+        potential radius. This parameter is used to give each column a
+        unique potential pool when a large potentialRadius causes
+        overlap between the columns. At initialization time we choose
+        ((2*potentialRadius + 1)^(# inputDimensions) * potentialPct)
+        input bits to comprise the column's potential pool.
+
+Argument globalInhibition If true, then during inhibition phase the
+        winning columns are selected as the most active columns from the
+        region as a whole. Otherwise, the winning columns are selected
+        with respect to their local neighborhoods. Global inhibition
+        boosts performance significantly but there is no topology at the
+        output.
+
+Argument localAreaDensity The desired density of active columns within
+        a local inhibition area (the size of which is set by the
+        internally calculated inhibitionRadius, which is in turn
+        determined from the average size of the connected potential
+        pools of all columns). The inhibition logic will insure that at
+        most N columns remain ON within a local inhibition area, where
+        N = localAreaDensity * (total number of columns in inhibition
+        area). 
+    If localAreaDensity is set to any value less than  0, 
+    output sparsity will be determined by the numActivePerInhArea.
+
+Argument numActiveColumnsPerInhArea An alternate way to control the sparsity of
+        active columns. When numActivePerInhArea > 0, the inhibition logic will insure that
+        at most 'numActivePerInhArea' columns remain ON within a local
+        inhibition area (the size of which is set by the internally
+        calculated inhibitionRadius). When using this method, as columns
+        learn and grow their effective receptive fields, the
+        inhibitionRadius will grow, and hence the net density of the
+        active columns will *decrease*. This is in contrast to the
+        localAreaDensity method, which keeps the density of active
+        columns the same regardless of the size of their receptive
+        fields.
+    If numActivePerInhArea is specified then 
+    localAreaDensity must be < 0, and vice versa.
+
+Argument stimulusThreshold This is a number specifying the minimum
+        number of synapses that must be active in order for a column to
+        turn ON. The purpose of this is to prevent noisy input from
+        activating columns.
+
+Argument synPermInactiveDec The amount by which the permanence of an
+        inactive synapse is decremented in each learning step.
+
+Argument synPermActiveInc The amount by which the permanence of an
+        active synapse is incremented in each round.
+
+Argument synPermConnected The default connected threshold. Any synapse
+        whose permanence value is above the connected threshold is
+        a "connected synapse", meaning it can contribute to
+        the cell's firing.
+
+Argument minPctOverlapDutyCycle A number between 0 and 1.0, used to set
+        a floor on how often a column should have at least
+        stimulusThreshold active inputs. Periodically, each column looks
+        at the overlap duty cycle of all other column within its
+        inhibition radius and sets its own internal minimal acceptable
+        duty cycle to: minPctDutyCycleBeforeInh * max(other columns'
+        duty cycles). On each iteration, any column whose overlap duty
+        cycle falls below this computed value will get all of its
+        permanence values boosted up by synPermActiveInc. Raising all
+        permanences in response to a sub-par duty cycle before
+        inhibition allows a cell to search for new inputs when either
+        its previously learned inputs are no longer ever active, or when
+        the vast majority of them have been "hijacked" by other columns.
+
+Argument dutyCyclePeriod The period used to calculate duty cycles.
+        Higher values make it take longer to respond to changes in
+        boost. Shorter values make it potentially more unstable and
+        likely to oscillate.
+
+Argument boostStrength A number greater or equal than 0, used to
+        control boosting strength. No boosting is applied if it is set to 0.
+        The strength of boosting increases as a function of boostStrength.
+        Boosting encourages columns to have similar activeDutyCycles as their
+        neighbors, which will lead to more efficient use of columns. However,
+        too much boosting may also lead to instability of SP outputs.
+
+
+Argument seed Seed for our random number generator. If seed is < 0
+        a randomly generated seed is used. The behavior of the spatial
+        pooler is deterministic once the seed is set.
+
+Argument spVerbosity spVerbosity level: 0, 1, 2, or 3
+
+Argument wrapAround boolean value that determines whether or not inputs
+        at the beginning and end of an input dimension are considered
+        neighbors for the purpose of mapping inputs to columns.
+)"
             , py::arg("inputDimensions") = vector<UInt>({ 32, 32 })
             , py::arg("columnDimensions") = vector<UInt>({ 64, 64 })
             , py::arg("potentialRadius") = 16
@@ -87,28 +206,6 @@ using namespace nupic;
             , py::arg("wrapAround") = true
         );
 
-        py_SpatialPooler.def("initialize", &SpatialPooler::initialize
-            , py::call_guard<py::scoped_ostream_redirect,
-                             py::scoped_estream_redirect>()
-            , py::arg("inputDimensions") = vector<UInt>({ 32, 32 })
-            , py::arg("columnDimensions") = vector<UInt>({ 64, 64 })
-            , py::arg("potentialRadius") = 16
-            , py::arg("potentialPct") = 0.5
-            , py::arg("globalInhibition") = false
-            , py::arg("localAreaDensity") = -1.0
-            , py::arg("numActiveColumnsPerInhArea") = 10
-            , py::arg("stimulusThreshold") = 0
-            , py::arg("synPermInactiveDec") = 0.01
-            , py::arg("synPermActiveInc") = 0.1
-            , py::arg("synPermConnected") = 0.1
-            , py::arg("minPctOverlapDutyCycle") = 0.001
-            , py::arg("dutyCyclePeriod") = 1000
-            , py::arg("boostStrength") = 0.0
-            , py::arg("seed") = -1
-            , py::arg("spVerbosity") = 0
-            , py::arg("wrapAround") = true);
-
-
         py_SpatialPooler.def("getColumnDimensions", &SpatialPooler::getColumnDimensions);
         py_SpatialPooler.def("getInputDimensions", &SpatialPooler::getInputDimensions);
         py_SpatialPooler.def("getNumColumns", &SpatialPooler::getNumColumns);
@@ -119,7 +216,6 @@ using namespace nupic;
         py_SpatialPooler.def("setPotentialPct", &SpatialPooler::setPotentialPct);
         py_SpatialPooler.def("getGlobalInhibition", &SpatialPooler::getGlobalInhibition);
         py_SpatialPooler.def("setGlobalInhibition", &SpatialPooler::setGlobalInhibition);
-
 
         py_SpatialPooler.def("getNumActiveColumnsPerInhArea", &SpatialPooler::getNumActiveColumnsPerInhArea);
         py_SpatialPooler.def("setNumActiveColumnsPerInhArea", &SpatialPooler::setNumActiveColumnsPerInhArea);
@@ -176,11 +272,33 @@ using namespace nupic;
         // compute
         py_SpatialPooler.def("compute", [](SpatialPooler& self, SDR& input, bool learn, SDR& output)
             { self.compute( input, learn, output ); },
-	    "SpatialPooler compute method",
-	    py::arg("input"),
-	    py::arg("learn") = true,
-	    py::arg("output")
-	    ); 
+R"(
+This is the main workhorse method of the SpatialPooler class. This method
+takes an input SDR and computes the set of output active columns. If 'learn' is
+set to True, this method also performs learning.
+
+Argument input An SDR that comprises the input to the spatial pooler.  The size
+        of the SDR must match total number of input bits implied by the
+        constructor (also returned by the method getNumInputs).
+
+Argument learn A boolean value indicating whether learning should be
+        performed. Learning entails updating the permanence values of
+        the synapses, duty cycles, etc. Learning is typically on but
+        setting learning to 'off' is useful for analyzing the current
+        state of the SP. For example, you might want to feed in various
+        inputs and examine the resulting SDR's. Note that if learning
+        is off, boosting is turned off and columns that have never won
+        will be removed from activeVector.  TODO: we may want to keep
+        boosting on even when learning is off.
+
+Argument output An SDR representing the winning columns after
+        inhibition. The size of the SDR is equal to the number of
+        columns (also returned by the method getNumColumns).
+)",
+        py::arg("input"),
+        py::arg("learn") = true,
+        py::arg("output")
+        ); 
 
         // setBoostFactors
         py_SpatialPooler.def("setBoostFactors", [](SpatialPooler& self, py::array& x)
@@ -332,9 +450,6 @@ using namespace nupic;
 
             return sp;
         }));
-
-
-
 
     }
 } // namespace nupic_ext

--- a/bindings/py/cpp_src/bindings/encoders/encoders_module.cpp
+++ b/bindings/py/cpp_src/bindings/encoders/encoders_module.cpp
@@ -55,10 +55,10 @@ Reference: https://arxiv.org/pdf/1602.05925.pdf
 
 
 CategoryEncoders:
-    To make encode categories of input, make either a ScalarEncoder or a
-RandomDistributedScalarEncoder, and set the "radius" parameter to 1.  Then
-enumerate your categories into integers before encoding them.
-)";
+
+    To encode categories of input, make a ScalarEncoder or a Random Distributed
+Scalar Encoder (RDSE), and set the parameter category=True.  Then enumerate your
+categories into integers before encoding them. )";
 
     init_ScalarEncoder(m);
     init_RDSE(m);


### PR DESCRIPTION
- Copied SpatialPooler documentation from C++ to python bindings
- Removed SP.initialize, use `__init__` method instead
- Fixed encoder docs