### PR TITLE
Dimensions: remove unneeded copy-constructor

### DIFF
--- a/src/htm/engine/Output.hpp
+++ b/src/htm/engine/Output.hpp
@@ -177,7 +177,7 @@ public:
   /**
    * Set dimensions for this output
    */
-  void setDimensions(const Dimensions& dim) { dim_ = dim; }
+  void setDimensions(const Dimensions& dim) { dim_ = std::move(dim); }
 
   /**
    *  Print raw data...for debugging

--- a/src/htm/engine/RegionImpl.hpp
+++ b/src/htm/engine/RegionImpl.hpp
@@ -292,7 +292,7 @@ public:
    * This cannot be used to override a fixed buffer setting in the Spec.
    * Args: dim   - The dimensions to set
    */
-  virtual void setDimensions(Dimensions dim) { dim_ = dim; }
+  virtual void setDimensions(Dimensions dim) { dim_ = std::move(dim); }
   virtual Dimensions getDimensions() const { return dim_; }
 
 

--- a/src/htm/ntypes/Dimensions.hpp
+++ b/src/htm/ntypes/Dimensions.hpp
@@ -55,7 +55,6 @@ public:
   Dimensions(UInt x, UInt y) {  vec_.push_back(x); vec_.push_back(y); }
   Dimensions(UInt x, UInt y, UInt z) { vec_.push_back(x); vec_.push_back(y); vec_.push_back(z); }
   Dimensions(const std::vector<UInt>& v) { vec_ = v; };
-  Dimensions(const Dimensions& d) : vec_(d.asVector()) {};
 
   /**
    * @returns  The count of cells in the grid which is the product of the sizes of


### PR DESCRIPTION
required for gcc-9 where explicit copy-constructor disables implicit operator=